### PR TITLE
very simple typo in docs

### DIFF
--- a/doc/app_reuse.rst
+++ b/doc/app_reuse.rst
@@ -257,7 +257,7 @@ from the dictionary that we return from ``mount_wiki()``.
 What if we want to use ``wiki_app`` by itself, as a WSGI app? That can
 be useful, also for testing purposes. It needs this ``wiki_id``
 parameter now. We simply pass it the ``wiki_id`` parameter when we
-instantiate it::
+instantiate it:
 
 .. code-block:: python
 


### PR DESCRIPTION
That code-block didn't render properly on the docs.

Note that I could not test the fix (BAD!) as I've been unable to "make html", anyway I'm pretty sure it's ok :)
