### PR TITLE
Adds Converter.__hash__ to fix Python 3 tests

### DIFF
--- a/morepath/converter.py
+++ b/morepath/converter.py
@@ -17,6 +17,11 @@ class Converter(object):
 
     Used for decoding/encoding URL parameters and path parameters.
     """
+
+    # must be set explicitly because __eq__ is defined below.
+    # see https://docs.python.org/3.1/reference/datamodel.html#object.__hash__
+    __hash__ = object.__hash__
+
     def __init__(self, decode, encode=None):
         """Create new converter.
 


### PR DESCRIPTION
Currently the Python 3 tests are failing because types that define `__eq__` are unhashable in Python 3, unless otherwise specified.

See https://docs.python.org/3.1/reference/datamodel.html#object.__hash__

> If a class that overrides __eq__() needs to retain the implementation of **hash**() from a parent class, the interpreter must be told this explicitly by setting __hash__ = <ParentClass>.__hash__. Otherwise the inheritance of **hash**() will be blocked, just as if **hash** had been explicitly set to None.
