### PR TITLE
Adds the ability to pass arguments to the tox command.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps=
      -e{toxinidir}/fixture_packages/ns
      -e{toxinidir}/fixture_packages/no_mp_ns
      -e{toxinidir}/fixture_packages/ns2
-commands=py.test morepath
+commands=py.test morepath {posargs}
 
 [flake8]
 ignore = N801


### PR DESCRIPTION
With it I can run a single tests over many pythons like this:

```
tox -- -k test_a_specific_test
```

See http://tox.readthedocs.org/en/latest/example/general.html#interactively-passing-positional-arguments
