### PR TITLE
Rename request.path to request.resolve_path.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,7 +24,7 @@ CHANGES
 
   Fixes https://github.com/morepath/morepath/issues/283
 
-- Introduce a ``request.path`` method that allows you to resolve
+- Introduce a ``request.resolve_path`` method that allows you to resolve
   paths to objects programmatically.
 
 - Modify ``setup.py`` to use ``io.open`` instead of ``open`` to

--- a/morepath/request.py
+++ b/morepath/request.py
@@ -185,7 +185,7 @@ class Request(BaseRequest):
             result += '?' + urlencode(parameters, True)
         return result
 
-    def path(self, path, app=SAME_APP):
+    def resolve_path(self, path, app=SAME_APP):
         """Resolve a path to a model instance.
 
         The resulting object is a model instance, or ``None`` if the

--- a/morepath/tests/test_path_directive.py
+++ b/morepath/tests/test_path_directive.py
@@ -1555,7 +1555,7 @@ def test_error_when_path_variables_isnt_dict():
         c.get('/models/1')
 
 
-def test_path_method_on_request_same_app():
+def test_resolve_path_method_on_request_same_app():
     config = setup()
 
     class App(morepath.App):
@@ -1571,15 +1571,15 @@ def test_path_method_on_request_same_app():
 
     @App.view(model=Model)
     def default(self, request):
-        return text_type(isinstance(request.path('simple'), Model))
+        return text_type(isinstance(request.resolve_path('simple'), Model))
 
     @App.view(model=Model, name='extra')
     def extra(self, request):
-        return text_type(request.path('nonexistent') is None)
+        return text_type(request.resolve_path('nonexistent') is None)
 
     @App.view(model=Model, name='appnone')
     def appnone(self, request):
-        return request.path('simple', app=None)
+        return request.resolve_path('simple', app=None)
 
     config.commit()
 
@@ -1593,7 +1593,7 @@ def test_path_method_on_request_same_app():
         c.get('/simple/appnone')
 
 
-def test_path_method_on_request_different_app():
+def test_resolve_path_method_on_request_different_app():
     config = setup()
 
     class App(morepath.App):
@@ -1609,7 +1609,7 @@ def test_path_method_on_request_different_app():
 
     @App.view(model=Model)
     def default(self, request):
-        obj = request.path('p', app=request.app.child('sub'))
+        obj = request.resolve_path('p', app=request.app.child('sub'))
         return text_type(isinstance(obj, SubModel))
 
     class Sub(morepath.App):


### PR DESCRIPTION
This keeps compatibility with webob.request.BaseRequest, where 'path' is a
property. See #292.