### PR TITLE
Magnus lycka patch permission rule

### DIFF
--- a/doc/superpowers.rst
+++ b/doc/superpowers.rst
@@ -82,11 +82,11 @@ accessible if the user has an edit permission::
       return "Editable"
 
 How does Morepath know whether someone has ``Edit`` permission? We
-need to tell it using the :meth:`morepath.App.permission`
+need to tell it using the :meth:`morepath.App.permission_rule`
 directive. We can implement any rule we want, for instance this one::
 
-  @App.permission(model=Document, permission=Edit)
-  def have_edit_permission(model, identity):
+  @App.permission_rule(model=Document, permission=Edit)
+  def have_edit_permission(identity, model, permission):
       return model.has_permission(identity.userid)
 
 Instead of a specific rule that only works for ``Document``, we can

--- a/doc/views.rst
+++ b/doc/views.rst
@@ -264,7 +264,7 @@ You can use such a class with a view::
       return 'edit document'
 
 You can define which users have what permission on which models by using
-the :meth:`morepath.App.permission` decorator. To learn more,
+the :meth:`morepath.App.permission_rule` decorator. To learn more,
 read :doc:`security`.
 
 Manipulating the response


### PR DESCRIPTION
I suspect that there has been a change in the permission API which isn't fully reflected in the docs yet: I needed to write @App.permission_rule instead of just @App.permission, and pass in (identity, model, permission) instead of (model, identity).