### PR TITLE
Auto-commit an application upon the first WSGI request

### DIFF
--- a/morepath/app.py
+++ b/morepath/app.py
@@ -106,6 +106,8 @@ class App(dectate.App):
         # this in turn uses a cached lookup from the reg_registry
         # the caching happens on the reg_registry and not here to
         # ensure that each instance of App uses the same cache.
+        if not self.is_committed():
+            self.commit()
         return self.config.reg_registry.lookup
 
     def set_implicit(self):

--- a/morepath/tests/test_defer_links.py
+++ b/morepath/tests/test_defer_links.py
@@ -1,5 +1,4 @@
 import morepath
-import dectate
 from webtest import TestApp as Client
 from morepath.error import LinkError
 import pytest
@@ -41,8 +40,6 @@ def test_defer_links():
     def defer_links_sub_model(app, obj):
         return app.child(Sub())
 
-    dectate.commit(Root, Sub)
-
     c = Client(Root())
 
     response = c.get('/')
@@ -83,8 +80,6 @@ def test_defer_view():
     def defer_links_sub_model(app, obj):
         return app.child(Sub())
 
-    dectate.commit(Root, Sub)
-
     c = Client(Root())
 
     response = c.get('/')
@@ -122,8 +117,6 @@ def test_defer_view_predicates():
     def defer_links_sub_model(app, obj):
         return app.child(Sub())
 
-    dectate.commit(Root, Sub)
-
     c = Client(Root())
 
     response = c.get('/')
@@ -160,8 +153,6 @@ def test_defer_view_missing_view():
     @Root.defer_links(model=SubModel)
     def defer_links_sub_model(app, obj):
         return app.child(Sub())
-
-    dectate.commit(Root, Sub)
 
     c = Client(Root())
 
@@ -204,8 +195,6 @@ def test_defer_links_mount_parameters():
     def defer_links_sub_model(app, obj):
         return app.child(sub(name=obj.name))
 
-    dectate.commit(root, sub)
-
     c = Client(root())
 
     response = c.get('/')
@@ -244,8 +233,6 @@ def test_defer_link_acquisition():
     def get_parent(app, obj):
         return app.parent
 
-    dectate.commit(root, sub)
-
     c = Client(root())
 
     response = c.get('/sub')
@@ -283,8 +270,6 @@ def test_defer_view_acquisition():
     @sub.defer_links(model=Model)
     def get_parent(app, obj):
         return app.parent
-
-    dectate.commit(root, sub)
 
     c = Client(root())
 
@@ -325,8 +310,6 @@ def test_defer_link_acquisition_blocking():
 
     # no defer_links_to_parent
 
-    dectate.commit(root, sub)
-
     c = Client(root())
 
     response = c.get('/sub')
@@ -362,8 +345,6 @@ def test_defer_view_acquisition_blocking():
         return sub()
 
     # no defer_links_to_parent
-
-    dectate.commit(root, sub)
 
     c = Client(root())
 
@@ -408,8 +389,6 @@ def test_defer_link_should_not_cause_web_views_to_exist():
     def get_parent(app, obj):
         return app.parent
 
-    dectate.commit(root, sub)
-
     c = Client(root())
 
     response = c.get('/sub')
@@ -439,8 +418,6 @@ def test_defer_link_to_parent_from_root():
     @root.defer_links(model=OtherModel)
     def get_parent(app, obj):
         return app.parent
-
-    dectate.commit(root, sub)
 
     c = Client(root())
 
@@ -488,8 +465,6 @@ def test_special_link_overrides_deferred_link():
     @root.defer_links(model=AlphaModel)
     def defer_links_alpha(app, obj):
         return app.child(alpha())
-
-    dectate.commit(root, alpha)
 
     c = Client(root())
 
@@ -545,8 +520,6 @@ def test_deferred_deferred_link():
     @root.defer_links(model=AlphaModel)
     def defer_links_alpha(app, obj):
         return app.child(alpha())
-
-    dectate.commit(alpha, beta, root)
 
     c = Client(root())
 
@@ -607,8 +580,6 @@ def test_deferred_deferred_view():
     def defer_links_alpha(app, obj):
         return app.child(alpha())
 
-    dectate.commit(root, alpha, beta)
-
     c = Client(root())
 
     response = c.get('/')
@@ -663,8 +634,6 @@ def test_deferred_view_has_app_of_defer():
     def defer_links_parent(app, obj):
         return app.parent.child('alpha')
 
-    dectate.commit(root, alpha, beta)
-
     c = Client(root())
 
     response = c.get('/beta')
@@ -702,8 +671,6 @@ def test_deferred_loop():
     @root.defer_links(model=Model)
     def defer_links_alpha(app, obj):
         return app.child(alpha())
-
-    dectate.commit(root, alpha)
 
     c = Client(root())
 
@@ -758,8 +725,6 @@ def test_defer_link_scenario():
         return {
             'app': 'Child',
         }
-
-    dectate.commit(App, Child)
 
     c = Client(App())
 

--- a/morepath/tests/test_directive.py
+++ b/morepath/tests/test_directive.py
@@ -17,8 +17,6 @@ def setup_module(module):
 
 
 def test_basic():
-    dectate.commit(basic.app)
-
     c = Client(basic.app())
 
     response = c.get('/foo')
@@ -30,8 +28,6 @@ def test_basic():
 
 
 def test_basic_json():
-    dectate.commit(basic.app)
-
     c = Client(basic.app())
 
     response = c.get('/foo/json')
@@ -40,8 +36,6 @@ def test_basic_json():
 
 
 def test_basic_root():
-    dectate.commit(basic.app)
-
     c = Client(basic.app())
 
     response = c.get('/')
@@ -55,8 +49,6 @@ def test_basic_root():
 
 
 def test_nested():
-    dectate.commit(nested.outer_app, nested.app)
-
     c = Client(nested.outer_app())
 
     response = c.get('/inner/foo')
@@ -68,8 +60,6 @@ def test_nested():
 
 
 def test_abbr():
-    dectate.commit(abbr.app)
-
     c = Client(abbr.app())
 
     response = c.get('/foo')
@@ -80,8 +70,6 @@ def test_abbr():
 
 
 def test_scanned_static_method():
-    dectate.commit(method.app)
-
     c = Client(method.app())
 
     response = c.get('/static')
@@ -93,12 +81,12 @@ def test_scanned_static_method():
 
 def test_scanned_no_converter():
     with pytest.raises(DirectiveReportError):
-        dectate.commit(noconverter.app)
+        noconverter.app.commit()
 
 
 def test_scanned_conflict():
     with pytest.raises(ConflictError):
-        dectate.commit(conflict.app)
+        conflict.app.commit()
 
 
 def test_basic_scenario():
@@ -137,8 +125,6 @@ def test_basic_scenario():
     @app.view(model=Root, name='link')
     def root_link(self, request):
         return request.link(self)
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -186,8 +172,6 @@ def test_link_to_unknown_model():
         except LinkError:
             return "Link Error"
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/')
@@ -216,8 +200,6 @@ def test_link_to_none():
     @app.view(model=Root, name='default')
     def root_link_with_default(self, request):
         return request.link(None, default='unknown')
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -254,8 +236,6 @@ def test_link_with_parameters():
     def link(self, request):
         return request.link(self)
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/foo')
@@ -289,8 +269,6 @@ def test_root_link_with_parameters():
     def link(self, request):
         return request.link(self)
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/')
@@ -321,8 +299,6 @@ def test_link_with_prefix():
     @app.link_prefix()
     def link_prefix(request):
         return request.headers['TESTPREFIX']
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -356,8 +332,6 @@ def test_link_prefix_cache():
             request.callnumber += 1
         return str(request.callnumber)
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/link')
@@ -379,8 +353,6 @@ def test_link_with_invalid_prefix():
     @app.link_prefix()
     def link_prefix(request):
         return None
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -412,8 +384,6 @@ def test_implicit_variables():
     def link(self, request):
         return request.link(self)
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/foo/link')
@@ -443,8 +413,6 @@ def test_implicit_parameters():
     @app.view(model=Model, name='link')
     def link(self, request):
         return request.link(self)
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -482,8 +450,6 @@ def test_implicit_parameters_default():
     def link(self, request):
         return request.link(self)
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/foo')
@@ -513,8 +479,6 @@ def test_simple_root():
     def hello_view(self, request):
         return 'hello'
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/')
@@ -533,8 +497,6 @@ def test_json_directive():
     @app.json(model=Model)
     def json(self, request):
         return {'id': self.id}
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -555,8 +517,6 @@ def test_redirect():
     def default(self, request):
         return morepath.redirect('/')
 
-    dectate.commit(app)
-
     c = Client(app())
 
     c.get('/', status=302)
@@ -575,7 +535,7 @@ def test_root_conflict():
         pass
 
     with pytest.raises(ConflictError):
-        dectate.commit(app)
+        app.commit()
 
 
 def test_root_conflict2():
@@ -591,7 +551,7 @@ def test_root_conflict2():
         pass
 
     with pytest.raises(ConflictError):
-        dectate.commit(app)
+        app.commit()
 
 
 def test_root_no_conflict_different_apps():
@@ -628,7 +588,7 @@ def test_model_conflict():
         return A()
 
     with pytest.raises(ConflictError):
-        dectate.commit(app)
+        app.commit()
 
 
 def test_path_conflict():
@@ -650,7 +610,7 @@ def test_path_conflict():
         return B()
 
     with pytest.raises(ConflictError):
-        dectate.commit(app)
+        app.commit()
 
 
 def test_path_conflict_with_variable():
@@ -672,7 +632,7 @@ def test_path_conflict_with_variable():
         return B()
 
     with pytest.raises(ConflictError):
-        dectate.commit(app)
+        app.commit()
 
 
 def test_path_conflict_with_variable_different_converters():
@@ -694,7 +654,7 @@ def test_path_conflict_with_variable_different_converters():
         return B()
 
     with pytest.raises(ConflictError):
-        dectate.commit(app)
+        app.commit()
 
 
 def test_model_no_conflict_different_apps():
@@ -734,7 +694,7 @@ def test_view_conflict():
         pass
 
     with pytest.raises(ConflictError):
-        dectate.commit(app)
+        app.commit()
 
 
 def test_view_no_conflict_different_names():
@@ -752,7 +712,7 @@ def test_view_no_conflict_different_names():
     def b_view(self, request):
         pass
 
-    dectate.commit(app)
+    app.commit()
 
 
 def test_view_no_conflict_different_predicates():
@@ -770,7 +730,7 @@ def test_view_no_conflict_different_predicates():
     def b_view(self, request):
         pass
 
-    dectate.commit(app)
+    app.commit()
 
 
 def test_view_no_conflict_different_apps():
@@ -810,7 +770,7 @@ def test_view_conflict_with_json():
         pass
 
     with pytest.raises(ConflictError):
-        dectate.commit(app)
+        app.commit()
 
 
 def test_view_conflict_with_html():
@@ -829,7 +789,7 @@ def test_view_conflict_with_html():
         pass
 
     with pytest.raises(ConflictError):
-        dectate.commit(app)
+        app.commit()
 
 
 def test_function_conflict():
@@ -852,7 +812,7 @@ def test_function_conflict():
         pass
 
     with pytest.raises(ConflictError):
-        dectate.commit(app)
+        app.commit()
 
 
 def test_function_no_conflict_different_apps():
@@ -887,15 +847,11 @@ def test_run_app_with_context_without_it():
         def __init__(self, mount_id):
             self.mount_id = mount_id
 
-    dectate.commit(app)
-
     with pytest.raises(TypeError):
         app()
 
 
 def test_mapply_bug():
-    dectate.commit(mapply_bug.app)
-
     c = Client(mapply_bug.app())
 
     response = c.get('/')
@@ -922,8 +878,6 @@ def test_abbr_imperative():
         @view(name='edit')
         def edit(self, request):
             return "Edit view"
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -959,8 +913,6 @@ def test_abbr_exception():
     except ZeroDivisionError:
         pass
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/')
@@ -989,8 +941,6 @@ def test_abbr_imperative2():
         @view(name='edit')
         def edit(self, request):
             return "Edit view"
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -1026,8 +976,6 @@ def test_abbr_nested():
             def post(self, request):
                 return "Post"
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/')
@@ -1059,8 +1007,6 @@ def test_function_directive():
     def mygeneric_for_foo(o):
         return "The foo object: %s" % o
 
-    dectate.commit(app)
-
     a = app()
 
     assert mygeneric('blah', lookup=a.lookup) == 'The object: blah'
@@ -1083,8 +1029,6 @@ def test_classgeneric_function_directive():
     def mygeneric_for_foo(o):
         return "The foo object"
 
-    dectate.commit(app)
-
     a = app()
 
     assert mygeneric(object, lookup=a.lookup) == 'The object'
@@ -1106,8 +1050,6 @@ def test_staticmethod():
             assert isinstance(self, Root)
             return "Hello world"
 
-    dectate.commit(App)
-
     c = Client(App())
 
     response = c.get('/')
@@ -1128,8 +1070,6 @@ def test_classmethod_equivalent_to_staticmethod():
         def root_default(self, request):
             assert isinstance(self, Root)
             return "Hello world"
-
-    dectate.commit(App)
 
     c = Client(App())
 
@@ -1153,8 +1093,6 @@ def test_classmethod_bound_outside():
 
     App.view(model=Root)(A.root_default)
 
-    dectate.commit(App)
-
     c = Client(App())
 
     response = c.get('/')
@@ -1177,8 +1115,6 @@ def test_instantiation_before_config():
     @App.view(model=Hello)
     def hello_view(self, request):
         return 'hello'
-
-    dectate.commit(App)
 
     c = Client(app)
 

--- a/morepath/tests/test_excview.py
+++ b/morepath/tests/test_excview.py
@@ -1,4 +1,3 @@
-import dectate
 import morepath
 from webob.exc import HTTPNotFound
 from webtest import TestApp as Client
@@ -16,8 +15,6 @@ def test_404_http_exception():
     @app.path(path='')
     class Root(object):
         pass
-
-    dectate.commit(app)
 
     c = Client(app())
     c.get('/', status=404)
@@ -38,8 +35,6 @@ def test_other_exception_not_handled():
     def root_default(self, request):
         raise MyException()
 
-    dectate.commit(app)
-
     c = Client(app())
 
     # the WSGI web server will handle any unhandled errors and turn
@@ -59,8 +54,6 @@ def test_http_exception_excview():
     @app.view(model=HTTPNotFound)
     def notfound_default(self, request):
         return "Not found!"
-
-    dectate.commit(app)
 
     c = Client(app())
     response = c.get('/')
@@ -86,8 +79,6 @@ def test_other_exception_excview():
     def myexception_default(self, request):
         return "My exception"
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/')
@@ -108,8 +99,6 @@ def test_http_exception_excview_retain_status():
             response.status_code = self.code
         request.after(set_status)
         return "Not found!!"
-
-    dectate.commit(app)
 
     c = Client(app())
     response = c.get('/', status=404)
@@ -135,8 +124,6 @@ def test_excview_named_view():
     @app.view(model=MyException)
     def myexception_default(self, request):
         return "My exception"
-
-    dectate.commit(app)
 
     c = Client(app())
     response = c.get('/view')

--- a/morepath/tests/test_extend.py
+++ b/morepath/tests/test_extend.py
@@ -1,5 +1,4 @@
 import morepath
-import dectate
 from webtest import TestApp as Client
 
 
@@ -26,8 +25,6 @@ def test_extends():
     @Extending.view(model=User, name='edit')
     def edit_user(self, request):
         return "Edit user: %s" % self.username
-
-    dectate.commit(App, Extending)
 
     cl = Client(App())
     response = cl.get('/users/foo')
@@ -61,8 +58,6 @@ def test_overrides_view():
     def render_user2(self, request):
         return "USER: %s" % self.username
 
-    dectate.commit(App, Overriding)
-
     cl = Client(App())
     response = cl.get('/users/foo')
     assert response.body == b'User: foo'
@@ -93,8 +88,6 @@ def test_overrides_model():
         if username != 'bar':
             return None
         return User(username)
-
-    dectate.commit(App, Overriding)
 
     cl = Client(App())
     response = cl.get('/users/foo')

--- a/morepath/tests/test_implicit.py
+++ b/morepath/tests/test_implicit.py
@@ -1,4 +1,3 @@
-import dectate
 import morepath
 import reg
 from webtest import TestApp as Client
@@ -40,8 +39,6 @@ def test_implicit_function():
     @app.view(model=Model)
     def default(self, request):
         return one()
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -100,8 +97,6 @@ def test_implicit_function_mounted():
     def default(self, request):
         return "View for %s, message: %s" % (self.id, one())
 
-    dectate.commit(alpha, beta)
-
     c = Client(alpha())
 
     response = c.get('/mounted/1')
@@ -132,8 +127,6 @@ def test_implicit_disabled():
             return one()
         except reg.NoImplicitLookupError:
             return "No implicit found"
-
-    dectate.commit(app)
 
     c = Client(app())
 

--- a/morepath/tests/test_internal.py
+++ b/morepath/tests/test_internal.py
@@ -1,4 +1,3 @@
-import dectate
 import morepath
 from webtest import TestApp as Client
 
@@ -22,8 +21,6 @@ def test_internal():
     @app.json(model=Root, name='internal', internal=True)
     def root_internal(self, request):
         return 'Internal!'
-
-    dectate.commit(app)
 
     c = Client(app())
 

--- a/morepath/tests/test_json_obj.py
+++ b/morepath/tests/test_json_obj.py
@@ -1,4 +1,3 @@
-import dectate
 import morepath
 from webtest import TestApp as Client
 
@@ -23,8 +22,6 @@ def test_json_obj_dump():
     @app.dump_json(model=Model)
     def dump_model_json(self, request):
         return {'x': self.x}
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -62,8 +59,6 @@ def test_json_obj_load():
     def load_json(json, request):
         return Item(json['x'])
 
-    dectate.commit(app)
-
     c = Client(app())
 
     c.post_json('/', {'x': 'foo'})
@@ -88,8 +83,6 @@ def test_json_obj_load_default():
     def default(self, request):
         assert request.body_obj == request.json
         return 'done'
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -134,8 +127,6 @@ def test_json_body_model():
         elif json['@type'] == 'Item2':
             return Item2(json['x'])
 
-    dectate.commit(app)
-
     c = Client(app())
 
     c.post_json('/', {'@type': 'Item1', 'x': 'foo'})
@@ -162,8 +153,6 @@ def test_json_obj_load_no_json_post():
     def default(self, request):
         assert request.body_obj is None
         return 'done'
-
-    dectate.commit(app)
 
     c = Client(app())
 

--- a/morepath/tests/test_mount_directive.py
+++ b/morepath/tests/test_mount_directive.py
@@ -54,8 +54,6 @@ def test_mount_basic():
     def get_mounted(id):
         return mounted(id=id)
 
-    app.commit()
-
     c = Client(app())
 
     response = c.get('/foo')
@@ -88,8 +86,6 @@ def test_mount_none_should_fail():
     def mount_mounted(id):
         return None
 
-    app.commit()
-
     c = Client(app())
 
     c.get('/foo', status=404)
@@ -116,8 +112,6 @@ def test_mount_context():
     @app.mount(path='{id}', app=mounted)
     def get_context(id):
         return mounted(mount_id=id)
-
-    app.commit()
 
     c = Client(app())
 
@@ -148,8 +142,6 @@ def test_mount_context_parameters():
     @app.mount(path='mounts', app=mounted)
     def get_context(mount_id=0):
         return mounted(mount_id=mount_id)
-
-    app.commit()
 
     c = Client(app())
 
@@ -182,8 +174,6 @@ def test_mount_context_parameters_override_default():
     def get_context(id):
         return mounted(mount_id=id)
 
-    app.commit()
-
     c = Client(app())
 
     response = c.get('/foo')
@@ -207,8 +197,6 @@ def test_mount_context_standalone():
     @app.view(model=Root)
     def root_default(self, request):
         return "The root for mount id: %s" % self.mount_id
-
-    app.commit()
 
     c = Client(app(mount_id='foo'))
 
@@ -241,8 +229,6 @@ def test_mount_parent_link():
     @app.mount(path='{id}', app=mounted)
     def get_context(id):
         return mounted(mount_id=id)
-
-    app.commit()
 
     c = Client(app())
 
@@ -281,8 +267,6 @@ def test_mount_child_link():
                variables=lambda a: {'id': a.mount_id})
     def get_context(id):
         return mounted(mount_id=id)
-
-    app.commit()
 
     c = Client(app())
 
@@ -329,8 +313,6 @@ def test_mount_sibling_link():
     def get_context_second():
         return second()
 
-    app.commit()
-
     c = Client(app())
 
     response = c.get('/first/models/1')
@@ -353,8 +335,6 @@ def test_mount_sibling_link_at_root_app():
     def root_default(self, request):
         sibling = request.app.sibling('foo')
         return request.link(Item(3), app=sibling)
-
-    app.commit()
 
     c = Client(app())
 
@@ -395,8 +375,6 @@ def test_mount_child_link_unknown_child():
 
     # no mount directive so linking will fail
 
-    app.commit()
-
     c = Client(app())
 
     response = c.get('/')
@@ -423,8 +401,6 @@ def test_mount_child_link_unknown_parent():
         if parent is None:
             return 'link error'
         return request.link(Model('one'), app=parent)
-
-    app.commit()
 
     c = Client(app())
 
@@ -458,8 +434,6 @@ def test_mount_child_link_unknown_app():
             return "link error"
 
     # no mounting, so mounted is unknown when making link
-
-    app.commit()
 
     c = Client(app())
 
@@ -508,8 +482,6 @@ def test_mount_link_prefix():
     def get_root_link_through_mount(self, request):
         parent = request.app.parent
         return request.view(AppRoot(), app=parent, name='get-root-link')
-
-    App.commit()
 
     c = Client(App())
 
@@ -561,8 +533,6 @@ def test_request_view_in_mount():
                variables=lambda a: dict(id=a.mount_id))
     def get_context(id):
         return mounted(mount_id=id)
-
-    app.commit()
 
     c = Client(app())
 
@@ -623,8 +593,6 @@ def test_request_link_child_child():
     def subroot_parentage(self, request):
         ancestor = request.app.parent.parent
         return request.view(Root(), name='info', app=ancestor)
-
-    app.commit()
 
     c = Client(app())
 
@@ -691,8 +659,6 @@ def test_request_view_in_mount_broken():
 
     # deliberately don't mount so using view is broken
 
-    app.commit()
-
     c = Client(app())
 
     response = c.get('/')
@@ -732,8 +698,6 @@ def test_mount_implicit_converters():
     def get_context(id=0):
         return mounted(id=id)
 
-    app.commit()
-
     c = Client(app())
 
     response = c.get('/1')
@@ -764,8 +728,6 @@ def test_mount_explicit_converters():
     @app.mount(path='{id}', app=mounted, converters=dict(id=int))
     def get_context(id):
         return mounted(id=id)
-
-    app.commit()
 
     c = Client(app())
 
@@ -804,8 +766,6 @@ def test_mount_view_in_child_view():
     @app.mount(path="foo", app=fooapp)
     def mount_to_root():
         return fooapp()
-
-    app.commit()
 
     c = Client(app())
 
@@ -853,8 +813,6 @@ def test_mount_view_in_child_view_then_parent_view():
     def mount_to_root():
         return fooapp()
 
-    app.commit()
-
     c = Client(app())
 
     response = c.get('/')
@@ -887,8 +845,6 @@ def test_mount_directive_with_link_and_absorb():
     @app1.mount(path="foo", app=app2)
     def get_mount():
         return app2()
-
-    app1.commit()
 
     c = Client(app1())
 
@@ -927,8 +883,6 @@ def test_mount_named_child_link_explicit_name():
     def get_context():
         return mounted()
 
-    app.commit()
-
     c = Client(app())
 
     response = c.get('/')
@@ -965,8 +919,6 @@ def test_mount_named_child_link_name_defaults_to_path():
     @app.mount(path='subapp', app=mounted)
     def get_context():
         return mounted()
-
-    app.commit()
 
     c = Client(app())
 
@@ -1016,8 +968,6 @@ def test_named_mount_with_parameters():
         child = request.app.child('mounts/{mount_id}', mount_id=3)
         return request.link(Item(4), app=child)
 
-    app.commit()
-
     c = Client(app())
 
     response = c.get('/')
@@ -1063,8 +1013,6 @@ def test_named_mount_with_url_parameters():
         child = request.app.child('mounts', mount_id=3)
         return request.link(Item(4), app=child)
 
-    app.commit()
-
     c = Client(app())
 
     response = c.get('/')
@@ -1100,8 +1048,6 @@ def test_access_app_through_request():
                 variables=lambda a: {'mount_name': a.name})
     def mount_sub(mount_name):
         return sub(name=mount_name)
-
-    root.commit()
 
     c = Client(root())
 
@@ -1143,8 +1089,6 @@ def test_mount_ancestors():
     @app.mount(path='{id}', app=mounted)
     def get_mounted(id):
         return mounted(id=id)
-
-    app.commit()
 
     c = Client(app())
 
@@ -1198,8 +1142,6 @@ def test_breadthfist_vs_inheritance_on_commit():
     # which is not in general a valid traversal of the inheritance
     # graph, does not lead to partial commits and hence to
     # misconfigurations.
-
-    Root.commit()
 
     c = Client(Root())
 

--- a/morepath/tests/test_path_directive.py
+++ b/morepath/tests/test_path_directive.py
@@ -34,8 +34,6 @@ def test_simple_path_one_step():
     def link(self, request):
         return request.link(self)
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/simple')
@@ -64,8 +62,6 @@ def test_simple_path_two_steps():
     @app.view(model=Model, name='link')
     def link(self, request):
         return request.link(self)
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -96,8 +92,6 @@ def test_variable_path_one_step():
     def link(self, request):
         return request.link(self)
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/foo')
@@ -126,8 +120,6 @@ def test_variable_path_two_steps():
     @app.view(model=Model, name='link')
     def link(self, request):
         return request.link(self)
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -159,8 +151,6 @@ def test_variable_path_two_variables():
     def link(self, request):
         return request.link(self)
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/foo-one')
@@ -190,8 +180,6 @@ def test_variable_path_explicit_converter():
     @app.view(model=Model, name='link')
     def link(self, request):
         return request.link(self)
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -224,8 +212,6 @@ def test_variable_path_implicit_converter():
     @app.view(model=Model, name='link')
     def link(self, request):
         return request.link(self)
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -260,8 +246,6 @@ def test_variable_path_explicit_trumps_implicit():
     def link(self, request):
         return request.link(self)
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/1')
@@ -294,8 +278,6 @@ def test_url_parameter_explicit_converter():
     @app.view(model=Model, name='link')
     def link(self, request):
         return request.link(self)
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -335,8 +317,6 @@ def test_url_parameter_explicit_converter_get_converters():
     @app.view(model=Model, name='link')
     def link(self, request):
         return request.link(self)
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -378,8 +358,6 @@ def test_url_parameter_get_converters_overrides_converters():
     def link(self, request):
         return request.link(self)
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/?id=1')
@@ -415,8 +393,6 @@ def test_url_parameter_implicit_converter():
     @app.view(model=Model, name='link')
     def link(self, request):
         return request.link(self)
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -454,8 +430,6 @@ def test_url_parameter_explicit_trumps_implicit():
     @app.view(model=Model, name='link')
     def link(self, request):
         return request.link(self)
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -500,8 +474,6 @@ def test_decode_encode():
     def link(self, request):
         return request.link(self)
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/?id=foo')
@@ -535,7 +507,7 @@ def test_unknown_converter():
         return request.link(self)
 
     with pytest.raises(DirectiveReportError):
-        dectate.commit(app)
+        app.commit()
 
 
 def test_unknown_explicit_converter():
@@ -562,7 +534,7 @@ def test_unknown_explicit_converter():
         return request.link(self)
 
     with pytest.raises(DirectiveReportError):
-        dectate.commit(app)
+        app.commit()
 
 
 def test_default_date_converter():
@@ -586,8 +558,6 @@ def test_default_date_converter():
     @app.view(model=Model, name='link')
     def link(self, request):
         return request.link(self)
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -627,8 +597,6 @@ def test_default_datetime_converter():
     @app.view(model=Model, name='link')
     def link(self, request):
         return request.link(self)
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -680,8 +648,6 @@ def test_custom_date_converter():
     def link(self, request):
         return request.link(self)
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/?d=10-11-2012')
@@ -719,8 +685,6 @@ def test_variable_path_parameter_required_no_default():
     def link(self, request):
         return request.link(self)
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/?id=a')
@@ -748,8 +712,6 @@ def test_variable_path_parameter_required_with_default():
     @app.view(model=Model, name='link')
     def link(self, request):
         return request.link(self)
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -781,8 +743,6 @@ def test_type_hints_and_converters():
     def link(self, request):
         return request.link(self)
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/?d=20140120')
@@ -811,8 +771,6 @@ def test_link_for_none_means_no_parameter():
     @app.view(model=Model, name='link')
     def link(self, request):
         return request.link(self)
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -845,8 +803,6 @@ def test_path_and_url_parameter_converter():
     @app.view(model=Model, name='link')
     def link(self, request):
         return request.link(self)
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -881,8 +837,6 @@ def test_path_converter_fallback_on_view():
     def named(self, request):
         return "Named view on root"
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/1')
@@ -903,8 +857,6 @@ def test_root_named_link():
     def default(self, request):
         return request.link(self, 'foo')
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/')
@@ -923,7 +875,7 @@ def test_path_class_and_model_argument():
         pass
 
     with pytest.raises(ConfigError):
-        dectate.commit(app)
+        app.commit()
 
 
 def test_path_no_class_and_no_model_argument():
@@ -935,7 +887,7 @@ def test_path_no_class_and_no_model_argument():
         return None
 
     with pytest.raises(ConfigError):
-        dectate.commit(app)
+        app.commit()
 
 
 def test_url_parameter_list():
@@ -957,8 +909,6 @@ def test_url_parameter_list():
     @app.view(model=Model, name='link')
     def link(self, request):
         return request.link(self)
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -997,8 +947,6 @@ def test_url_parameter_list_empty():
     def link(self, request):
         return request.link(self)
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/?item=a&item=b')
@@ -1034,8 +982,6 @@ def test_url_parameter_list_explicit_converter():
     def link(self, request):
         return request.link(self)
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/?item=1&item=2')
@@ -1069,7 +1015,7 @@ def test_url_parameter_list_unknown_explicit_converter():
         return Model(item)
 
     with pytest.raises(DirectiveReportError):
-        dectate.commit(app)
+        app.commit()
 
 
 def test_url_parameter_list_but_only_one_allowed():
@@ -1091,8 +1037,6 @@ def test_url_parameter_list_but_only_one_allowed():
     @app.view(model=Model, name='link')
     def link(self, request):
         return request.link(self)
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -1120,8 +1064,6 @@ def test_extra_parameters():
     @app.view(model=Model, name='link')
     def link(self, request):
         return request.link(self)
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -1159,8 +1101,6 @@ def test_extra_parameters_with_get_converters():
     def link(self, request):
         return request.link(self)
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/?a=1&b=B')
@@ -1192,8 +1132,6 @@ def test_script_name():
     @app.view(model=Model, name='link')
     def link(self, request):
         return request.link(self)
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -1236,8 +1174,6 @@ def test_sub_path_different_variable():
     def default_s(self, request):
         return "S: %s %s" % (self.id, self.m)
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/a')
@@ -1273,8 +1209,6 @@ def test_absorb_path():
     @app.view(model=Root)
     def default_root(self, request):
         return request.link(Model('a/b'))
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -1319,8 +1253,6 @@ def test_absorb_path_with_variables():
     @app.view(model=Root)
     def default_root(self, request):
         return request.link(Model('foo', 'a/b'))
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -1376,8 +1308,6 @@ def test_absorb_path_explicit_subpath_ignored():
     def default_root(self, request):
         return request.link(Another())
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/foo/a')
@@ -1406,8 +1336,6 @@ def test_absorb_path_root():
     @app.view(model=Model)
     def default(self, request):
         return "A:%s L:%s" % (self.absorb, request.link(self))
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -1438,8 +1366,6 @@ def test_error_when_path_variable_is_none():
     def default(self, request):
         return request.link(self)
 
-    dectate.commit(App)
-
     c = Client(App())
 
     with pytest.raises(LinkError):
@@ -1463,8 +1389,6 @@ def test_error_when_path_variable_is_missing():
     def default(self, request):
         return request.link(self)
 
-    dectate.commit(App)
-
     c = Client(App())
 
     with pytest.raises(KeyError):
@@ -1487,8 +1411,6 @@ def test_error_when_path_variables_isnt_dict():
     @App.view(model=Model)
     def default(self, request):
         return request.link(self)
-
-    dectate.commit(App)
 
     c = Client(App())
 
@@ -1519,8 +1441,6 @@ def test_resolve_path_method_on_request_same_app():
     @App.view(model=Model, name='appnone')
     def appnone(self, request):
         return request.resolve_path('simple', app=None)
-
-    dectate.commit(App)
 
     c = Client(App())
 
@@ -1563,8 +1483,6 @@ def test_resolve_path_method_on_request_different_app():
     def mount_sub():
         return Sub()
 
-    dectate.commit(App, Sub)
-
     c = Client(App())
 
     response = c.get('/simple')
@@ -1586,8 +1504,6 @@ def test_resolve_path_with_dots_in_url():
     @app.view(model=Root)
     def default(self, request):
         return "%s" % self.absorb
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -1627,8 +1543,6 @@ def test_quoting_link_generation():
     def link(self, request):
         return request.link(self)
 
-    dectate.commit(App)
-
     c = Client(App())
 
     response = c.get('/sim%3Fple')
@@ -1657,8 +1571,6 @@ def test_quoting_link_generation_umlaut():
     @App.view(model=Model, name='link')
     def link(self, request):
         return request.link(self)
-
-    dectate.commit(App)
 
     c = Client(App())
 
@@ -1694,8 +1606,6 @@ def test_quoting_link_generation_tilde():
     def link(self, request):
         return request.link(self)
 
-    dectate.commit(App)
-
     c = Client(App())
 
     response = c.get('/sim~ple')
@@ -1724,8 +1634,6 @@ def test_parameter_quoting():
     @App.view(model=Model, name='link')
     def link(self, request):
         return request.link(self)
-
-    dectate.commit(App)
 
     c = Client(App())
 
@@ -1756,8 +1664,6 @@ def test_parameter_quoting_tilde():
     def link(self, request):
         return request.link(self)
 
-    dectate.commit(App)
-
     c = Client(App())
 
     response = c.get('/?s=sim~ple')
@@ -1782,8 +1688,6 @@ def test_class_link_without_variables():
     def link(self, request):
         return request.class_link(Model)
 
-    dectate.commit(App)
-
     c = Client(App())
 
     response = c.get('/foo')
@@ -1804,8 +1708,6 @@ def test_class_link_no_app():
     @App.view(model=Model)
     def link(self, request):
         return request.class_link(Model, app=None)
-
-    dectate.commit(App)
 
     c = Client(App())
 
@@ -1828,8 +1730,6 @@ def test_class_link_with_variables():
     def link(self, request):
         return request.class_link(Model, variables={'x': 'X'})
 
-    dectate.commit(App)
-
     c = Client(App())
 
     response = c.get('/foo/3')
@@ -1850,8 +1750,6 @@ def test_class_link_with_missing_variables():
     @App.view(model=Model)
     def link(self, request):
         return request.class_link(Model, variables={})
-
-    dectate.commit(App)
 
     c = Client(App())
 
@@ -1874,8 +1772,6 @@ def test_class_link_with_extra_variable():
     def link(self, request):
         return request.class_link(Model, variables={'x': 'X', 'y': 'Y'})
 
-    dectate.commit(App)
-
     c = Client(App())
 
     response = c.get('/foo/3')
@@ -1896,8 +1792,6 @@ def test_class_link_with_url_parameter_variable():
     @App.view(model=Model)
     def link(self, request):
         return request.class_link(Model, variables={'x': 'X', 'y': 'Y'})
-
-    dectate.commit(App)
 
     c = Client(App())
 
@@ -1922,8 +1816,6 @@ def test_class_link_with_subclass():
     @App.view(model=Model)
     def link(self, request):
         return request.class_link(Sub, variables={'x': 'X'})
-
-    dectate.commit(App)
 
     c = Client(App())
 
@@ -1957,8 +1849,6 @@ def test_absorb_class_path():
     @App.view(model=Root)
     def default_root(self, request):
         return request.class_link(Model, variables={'absorb': 'a/b'})
-
-    dectate.commit(App)
 
     c = Client(App())
 
@@ -1996,8 +1886,6 @@ def test_absorb_class_path_with_variables():
         return request.class_link(Model,
                                   variables=dict(id='foo', absorb='a/b'))
 
-    dectate.commit(App)
-
     c = Client(App())
 
     # link to a/b absorb
@@ -2027,8 +1915,6 @@ def test_class_link_extra_parameters():
             Model,
             variables={'extra_parameters': {'a': 'A', 'b': 'B'}})
 
-    dectate.commit(App)
-
     c = Client(App())
 
     response = c.get('/link?a=A&b=B')
@@ -2057,8 +1943,6 @@ def test_path_on_model_class():
     def login_view(self, request):
         return "Login"
 
-    dectate.commit(App)
-
     c = Client(App())
 
     response = c.get('/')
@@ -2076,7 +1960,7 @@ def test_path_without_model():
         pass
 
     with pytest.raises(dectate.DirectiveReportError):
-        dectate.commit(App)
+        App.commit()
 
 
 def test_two_path_on_same_model_should_conflict():
@@ -2089,7 +1973,7 @@ def test_two_path_on_same_model_should_conflict():
         pass
 
     with pytest.raises(dectate.ConflictError):
-        dectate.commit(App)
+        App.commit()
 
 
 def test_path_on_same_model_explicit_and_class_should_conflict():
@@ -2105,4 +1989,4 @@ def test_path_on_same_model_explicit_and_class_should_conflict():
         return Login()
 
     with pytest.raises(dectate.ConflictError):
-        dectate.commit(App)
+        App.commit()

--- a/morepath/tests/test_predicate.py
+++ b/morepath/tests/test_predicate.py
@@ -1,5 +1,4 @@
 import reg
-import dectate
 from reg import ClassIndex, KeyIndex
 import morepath
 from morepath.error import ConfigError
@@ -34,8 +33,6 @@ def test_dispatch():
     @App.function(f, obj=Bar)
     def f_bar(obj):
         return "bar"
-
-    dectate.commit(App)
 
     a = App()
 
@@ -74,8 +71,6 @@ def test_dispatch_external_predicates():
     @App.function(f, model=Bar)
     def f_bar(obj):
         return "bar"
-
-    dectate.commit(App)
 
     a = App()
 
@@ -118,8 +113,6 @@ def test_dispatch_external_predicates_predicate_fallback():
     @App.function(f, model=Bar)
     def f_bar(obj):
         return "bar"
-
-    dectate.commit(App)
 
     a = App()
 
@@ -170,8 +163,6 @@ def test_dispatch_external_predicates_ordering_after():
     @App.function(f, model=Bar, name='edit')
     def f_bar_edit(obj, name):
         return "bar edit"
-
-    dectate.commit(App)
 
     a = App()
 
@@ -227,8 +218,6 @@ def test_dispatch_external_predicates_ordering_before():
     @App.function(f, model=Bar, name='edit')
     def f_bar_edit(obj, name):
         return "bar edit"
-
-    dectate.commit(App)
 
     a = App()
 
@@ -286,8 +275,6 @@ def test_dispatch_external_override_fallback():
     @App.function(f, model=Bar)
     def f_bar(obj):
         return "bar"
-
-    dectate.commit(App, Sub)
 
     s = Sub()
     lookup = s.lookup
@@ -353,8 +340,6 @@ def test_dispatch_external_override_predicate():
     def f_bar_sub(obj):
         return "bar sub"
 
-    dectate.commit(App, Sub)
-
     s = Sub()
 
     lookup = s.lookup
@@ -383,14 +368,14 @@ def test_wrong_predicate_arguments_single():
     class Foo(object):
         pass
 
-    def bar(object):
-        pass
-
+    # @App.function(f, obj=Foo)
     @App.function(f, wrong=Foo)
     def f_foo(obj):
         return "foo"
 
-    dectate.commit(App)
+    a = App()
+
+    assert f(Foo(), lookup=a.lookup) == 'fallback'
 
 
 def test_wrong_predicate_arguments_multi():
@@ -404,14 +389,14 @@ def test_wrong_predicate_arguments_multi():
     class Foo(object):
         pass
 
-    def bar(object):
-        pass
-
+    # @App.function(f, a=Foo, b=Foo)
     @App.function(f, wrong=Foo)
     def f_foo(a, b):
         return "foo"
 
-    dectate.commit(App)
+    a = App()
+
+    assert f(Foo(), Foo(), lookup=a.lookup) == 'fallback'
 
 
 def test_predicate_not_for_dispatch_external_predicates():
@@ -427,7 +412,7 @@ def test_predicate_not_for_dispatch_external_predicates():
         return a.__class__
 
     with pytest.raises(ConfigError):
-        dectate.commit(App)
+        App().lookup
 
 
 def test_dispatch_external_predicates_without_predicate_directives():
@@ -450,8 +435,6 @@ def test_dispatch_external_predicates_without_predicate_directives():
     @App.function(f)
     def f_foo(obj):
         return "foo"
-
-    dectate.commit(App)
 
     a = App()
 

--- a/morepath/tests/test_predicates.py
+++ b/morepath/tests/test_predicates.py
@@ -1,4 +1,3 @@
-import dectate
 from morepath.app import App
 
 from webtest import TestApp as Client
@@ -26,8 +25,6 @@ def test_view_predicates():
     @app.view(model=Root, name='foo', request_method='POST')
     def post(self, request):
         return 'POST'
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -58,8 +55,6 @@ def test_extra_predicates():
                    after=morepath.request_method_predicate)
     def id_predicate(obj):
         return obj.id
-
-    dectate.commit(app)
 
     c = Client(app())
 

--- a/morepath/tests/test_scenario.py
+++ b/morepath/tests/test_scenario.py
@@ -1,4 +1,3 @@
-import importscan
 from .fixtures import scenario
 from .fixtures.scenario import app
 import morepath
@@ -11,8 +10,7 @@ def setup_module(module):
 
 
 def test_scenario():
-    importscan.scan(scenario)
-    app.Root.commit()
+    morepath.scan(scenario)
 
     c = Client(app.Root())
 

--- a/morepath/tests/test_security.py
+++ b/morepath/tests/test_security.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import dectate
 import morepath
 from morepath.request import Response
 from morepath import generic
@@ -37,8 +36,6 @@ def test_no_permission():
     @app.view(model=Model, permission=Permission)
     def default(self, request):
         return "Model: %s" % self.id
-
-    dectate.commit(app)
 
     c = Client(app())
 
@@ -87,8 +84,6 @@ def test_permission_directive_identity():
         def forget(self, response, request):
             pass
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/foo')
@@ -123,8 +118,6 @@ def test_permission_directive_no_identity():
     def default(self, request):
         return "Model: %s" % self.id
 
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/foo')
@@ -133,8 +126,6 @@ def test_permission_directive_no_identity():
 
 
 def test_policy_action():
-    dectate.commit(identity_policy.app)
-
     c = Client(identity_policy.app())
 
     response = c.get('/foo')
@@ -205,8 +196,6 @@ def test_cookie_identity_policy():
     def verify_identity(identity):
         return True
 
-    dectate.commit(app)
-
     c = Client(app(), cookiejar=CookieJar())
 
     response = c.get('/foo', status=403)
@@ -225,8 +214,6 @@ def test_default_verify_identity():
     class app(morepath.App):
         pass
 
-    dectate.commit(app)
-
     identity = morepath.Identity('foo')
 
     assert not generic.verify_identity(identity, lookup=app().lookup)
@@ -240,7 +227,6 @@ def test_verify_identity_directive():
     def verify_identity(identity):
         return identity.password == 'right'
 
-    dectate.commit(app)
     identity = morepath.Identity('foo', password='wrong')
     assert not generic.verify_identity(identity, lookup=app().lookup)
     identity = morepath.Identity('foo', password='right')
@@ -279,8 +265,6 @@ def test_false_verify_identity():
     @app.verify_identity()
     def verify_identity(identity):
         return False
-
-    dectate.commit(app)
 
     c = Client(app(), cookiejar=CookieJar())
 
@@ -349,8 +333,6 @@ def test_settings():
         def token_is_valid(self, token, encryption_key):
             return token == encryption_key  # fake validation
 
-    dectate.commit(App)
-
     c = Client(App())
 
     headers = {'Authorization': 'Bearer secret'}
@@ -370,8 +352,6 @@ def test_prevent_poisoned_host_headers():
     @App.view(model=Model)
     def view_model(self, request):
         return 'ok'
-
-    dectate.commit(App)
 
     poisoned_hosts = (
         'example.com@evil.tld',

--- a/morepath/tests/test_template.py
+++ b/morepath/tests/test_template.py
@@ -1,4 +1,3 @@
-import dectate
 import morepath
 from morepath.error import ConfigError
 from webtest import TestApp as Client
@@ -14,8 +13,6 @@ def setup_module(module):
 
 
 def test_template_fixture():
-    dectate.commit(template.App)
-
     c = Client(template.App())
 
     response = c.get('/world')
@@ -23,7 +20,6 @@ def test_template_fixture():
 
 
 def test_template_override_fixture():
-    dectate.commit(template_override.App, template_override.SubApp)
     c = Client(template_override.App())
 
     response = c.get('/world')
@@ -37,13 +33,10 @@ def test_template_override_fixture():
 
 def test_template_override_not_directed():
     with pytest.raises(ConfigError):
-        dectate.commit(template_override_under.App,
-                       template_override_under.SubApp)
+        template_override_under.SubApp.commit()
 
 
 def test_template_override_implicit_fixture():
-    dectate.commit(template_override_implicit.App,
-                   template_override_implicit.SubApp)
     c = Client(template_override_implicit.App())
 
     response = c.get('/world')
@@ -57,15 +50,16 @@ def test_template_override_implicit_fixture():
 
 def test_unknown_extension_no_loader():
     with pytest.raises(ConfigError):
-        dectate.commit(template_unknown_extension.App)
+        template_unknown_extension.App.commit()
 
 
 def test_unknown_extension_no_render():
     with pytest.raises(ConfigError):
-        dectate.commit(template_unknown_extension_no_render.App)
+        template_unknown_extension_no_render.App.commit()
 
 
 def test_no_template_directories():
     # we accept no template directories, as it is possible
     # for a base frameworky app not to define any (ChameleonApp, Jinja2App)
-    dectate.commit(template_no_template_directories.App)
+    assert template_no_template_directories.App.commit() == \
+        {template_no_template_directories.App}

--- a/morepath/tests/test_tween.py
+++ b/morepath/tests/test_tween.py
@@ -1,4 +1,3 @@
-import dectate
 import morepath
 from morepath.tween import TweenRegistry
 from morepath.error import TopologicalSortError
@@ -178,8 +177,6 @@ def test_tween_directive():
             response.headers['Tween-Header'] = 'FOO'
             return response
         return plusplustween
-
-    dectate.commit(app)
 
     c = Client(app())
 

--- a/morepath/tests/test_view_directive.py
+++ b/morepath/tests/test_view_directive.py
@@ -1,6 +1,5 @@
 import morepath
 from morepath import generic
-import dectate
 from dectate import ConflictError
 from webtest import TestApp as Client
 from reg import ClassIndex, KeyIndex
@@ -24,8 +23,6 @@ def test_view_get_only():
     @App.view(model=Model)
     def default(self, request):
         return "View"
-
-    dectate.commit(App)
 
     c = Client(App())
 
@@ -53,7 +50,7 @@ def test_view_name_conflict_involving_default():
         return "View"
 
     with pytest.raises(ConflictError):
-        dectate.commit(App)
+        App.commit()
 
 
 def test_view_custom_predicate_conflict_involving_default_extends():
@@ -83,7 +80,7 @@ def test_view_custom_predicate_conflict_involving_default_extends():
         return "View"
 
     with pytest.raises(ConflictError):
-        dectate.commit(Core, App)
+        App.commit()
 
 
 def test_view_custom_predicate_without_fallback():
@@ -111,8 +108,6 @@ def test_view_custom_predicate_without_fallback():
     @App.view(model=Model, name='foo', extra='not match')
     def not_match(self, request):
         return "Not match"
-
-    dectate.commit(Core, App)
 
     c = Client(App())
 


### PR DESCRIPTION
This addresses #392.

- The check on whether the app is committed and automatic commit is carried out inside the reification of app.lookup, so it is outside the critical path of WSGI serving.

- If and when automatic commit takes place is examined in detail using config logging.

- Most of the tests with the following pattern have been modified by taking out dectate.commit:

  ```
  dectate.commit(app,...)
  c = Client(app())
  c.get(...)
  ```
- Similarly for tests with the following pattern:

  ```
  dectate.commit(app,...)
  a = app()
  ...a.lookup...
  ```

- A few additional tests have been slightly reformulated. 
 