### PR TITLE
Using doctests in the docs.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,7 +26,7 @@ import pkg_resources
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx',
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.doctest',
               'dectate.sphinxext']
 
 autoclass_content = 'both'

--- a/doc/paths_and_linking.rst
+++ b/doc/paths_and_linking.rst
@@ -485,7 +485,9 @@ namely ``20140115`` (and this what Morepath defaults to). But we could
 also use another representation, say ``15/01/2014``.
 
 Let's first see how a string with an ISO compact date can be decoded
-(deserialized, loaded) into a ``date`` object::
+(deserialized, loaded) into a ``date`` object:
+
+.. testcode::
 
   from datetime import date
   from time import mktime, strptime
@@ -493,29 +495,31 @@ Let's first see how a string with an ISO compact date can be decoded
   def date_decode(s):
       return date.fromtimestamp(mktime(strptime(s, '%Y%m%d')))
 
-We can try it out::
+We can try it out:
 
   >>> date_decode('20140115')
   datetime.date(2014, 1, 15)
 
 Note that this function raises a ``ValueError`` if we give it a string
-that cannot be converted into a date::
+that cannot be converted into a date:
 
-  >>> date_decode('blah')
+  >>> date_decode('blah')                # doctest: -IGNORE_EXCEPTION_DETAIL -ELLIPSIS
   Traceback (most recent call last):
      ...
-  ValueError: time data 'blah' does not match format '%Y-%m-%d'
+  ValueError: time data 'blah' does not match format '%Y%m%d'
 
 This is a general principle of decode: a decode function can fail and
 if it does it should raise a ``ValueError``.
 
 We also specify how to encode (serialize, dump) a ``date`` object back
-into a string::
+into a string:
+
+.. testcode::
 
   def date_encode(d):
       return d.strftime('%Y%m%d')
 
-We can try it out too::
+We can try it out too:
 
   >>> date_encode(date(2014, 1, 15))
   '20140115'


### PR DESCRIPTION
First step towards the introduction of doctests in the morepath documentation:

* No new documentation here. Only adding tests to the existing docs.

* sphinx.ext.doctest has [hard-coded defaults for the flags](https://github.com/sphinx-doc/sphinx/issues/2471) which are different from the default flags in the standard library.  If you want to catch the small diff in the exception detail (the string format) you need extra flags.