### PR TITLE
Added initial doc for automated tests

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -60,7 +60,7 @@ interpreter = ${buildout:directory}/bin/sphinxpython
 [sphinxpython]
 recipe = zc.recipe.egg
 interpreter = ${:_buildout_section_name_}
-eggs = morepath
+eggs = morepath[test]
 
 [releaser]
 recipe = zc.recipe.egg

--- a/doc/building_large_applications.rst
+++ b/doc/building_large_applications.rst
@@ -314,7 +314,8 @@ using an entry point in ``setup.py`` as we've seen in
 :doc:`organizing_your_project`.
 
 You can also mount applications this way in automated tests and then
-use WebTest_ or some other WSGI testing library.
+use WebTest_ or some other WSGI testing library, as explained in
+:doc:`testing`.
 
 .. _WebTest: http://webtest.readthedocs.org/
 

--- a/doc/code_examples/hello.py
+++ b/doc/code_examples/hello.py
@@ -1,0 +1,16 @@
+import morepath
+
+class App(morepath.App):
+    pass
+
+@App.path(path='')
+class Root(object):
+    pass
+
+@App.view(model=Root)
+def hello_world(self, request):
+    return "Hello world!"
+
+if __name__ == '__main__':
+    morepath.autocommit()
+    morepath.run(App())

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -17,7 +17,7 @@ import pkg_resources
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('code_examples'))
 
 # -- General configuration -----------------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -33,12 +33,14 @@ autoclass_content = 'both'
 
 autodoc_member_order = 'groupwise'
 
+# See also: http://stackoverflow.com/a/30981554
 intersphinx_mapping = {
     'reg': ('http://reg.readthedocs.org/en/latest', None),
     'importscan': ('http://importscan.readthedocs.org/en/latest', None),
     'dectate': ('http://dectate.readthedocs.org/en/latest', None),
     'webob': ('http://docs.webob.org/en/latest', None),
     'bowerstatic': ('http://bowerstatic.readthedocs.org/en/latest', None),
+    'webtest': ('http://webtest.readthedocs.org/en/latest', None),
     }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/developing.rst
+++ b/doc/developing.rst
@@ -102,6 +102,28 @@ And to see the maintainability index::
 
 .. _`cyclomatic complexity`: https://en.wikipedia.org/wiki/Cyclomatic_complexity
 
+Running the documentation tests
+-------------------------------
+
+The documentation contains code. To check these code snippets, you
+can run this code using this command::
+
+  $ bin/sphinxpython bin/sphinx-build -b doctest doc doc/build/doctest
+
+If you have Make_ installed, buildout generates for you a Makefile in
+the directory ``doc/build`` that you can use::
+
+  $ (cd doc/build; make doctest)
+
+.. _Make: https://en.wikipedia.org/wiki/Make_(software)
+
+Building the HTML documentation
+-------------------------------
+
+To build the HTML documentation (output in ``doc/build/html``), run::
+
+  $ bin/sphinxbuilder
+
 Deprecation
 -----------
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -24,6 +24,8 @@ Morepath itself, including an example of ``quickstart.py``.
 
 .. _virtualenv: http://www.virtualenv.org/
 
+.. _cookiecutter:
+
 Creating a Morepath Project Using Cookiecutter
 ----------------------------------------------
 

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -6,27 +6,14 @@ learn. This quickstart guide should help you get started. We assume
 you've already installed Morepath; if not, see the :doc:`installation`
 section.
 
+.. _helloworld:
+
 Hello world
 -----------
 
-Let's look at a minimal "Hello world!" application in Morepath::
+Let's look at a minimal "Hello world!" application in Morepath:
 
-  import morepath
-
-  class App(morepath.App):
-      pass
-
-  @App.path(path='')
-  class Root(object):
-      pass
-
-  @App.view(model=Root)
-  def hello_world(self, request):
-      return "Hello world!"
-
-  if __name__ == '__main__':
-      morepath.autocommit()
-      morepath.run(App())
+.. literalinclude:: code_examples/hello.py
 
 You can save this as ``hello.py`` and then run it with Python:
 

--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -8,50 +8,59 @@ see the :doc:`installation` section.
 In order to carry out the test we'll use WebTest_, which you'll need
 to have installed. You'll want to have a test automation tool like
 pytest_ too.  The :ref:`cookiecutter template <cookiecutter>` installs
-both for you, alternatively you can install both with pip:
+both for you, alternatively you can install them with pip:
 
-.. code-block:: sh
+.. code-block:: console
 
   $ pip install webtest pytest
 
 
-Testing a basic app
--------------------
+Testing "Hello world!"
+----------------------
 
-Let’s look at a minimal test of a basic app in Morepath:
+Let’s look at a minimal test of the "Hello world!" application from
+the :doc:`quickstart`:
 
 .. testcode::
 
-  def test_basic():
-      from morepath.tests.fixtures import basic
+  def test_hello():
+      from hello import App
       from webtest import TestApp as Client
 
-      c = Client(basic.app())
+      c = Client(App())
 
-      response = c.get('/foo')
+      response = c.get('/')
 
-      assert response.body == b'The view for model: foo'
+      assert response.body == b'Hello world!'
 
-You can save this function into a file and use a test automation tool
-like pytest_ to run it, or you can also invoke it as a regular Python
-function --- in this case a silent completion signifies success:
+You can save this function into a file, say ``test_hello.py`` and use
+a test automation tool like pytest_ to run it:
 
-  >>> test_basic()
+.. code-block:: console
+
+   $ py.test -q test_hello.py
+   .
+   1 passed in 0.13 seconds
+
+If you invoke it as a regular Python function, a silent completion
+signifies success:
+
+  >>> test_hello()
 
 .. _pytest: https://pytest.org
 
 Let's now go through the test, line by line.
 
 1. We import the application that we want to test.  In this case we
-   are going to use one of the simple apps that are part of the test
-   suite distributed with Morepath:
+   assume that you have saved the "Hello world!" application from
+   the :doc:`quickstart` in ``hello.py``:
 
-   >>> from morepath.tests.fixtures import basic
+   >>> from hello import App
 
    You can additionally use :func:`morepath.scan` if you are not sure
    whether importing the app imports all the modules that are
    required. In this particular instance, we know that importing
-   ``basic`` is sufficient and :func:`morepath.scan` is not needed.
+   ``hello`` is sufficient and :func:`morepath.scan` is not needed.
 
 2. WebTest_ provides a class called :class:`webtest.app.TestApp`
    that emulates a client for WSGI apps.  Lest we confuse it with the
@@ -61,17 +70,17 @@ Let's now go through the test, line by line.
 
 3. We instantiate the app under test and the client:
 
-   >>> c = Client(basic.app())
+   >>> c = Client(App())
 
 4. At this point we can use the client to query the app:
 
-   >>> response = c.get('/foo')
+   >>> response = c.get('/')
 
    The returned response is an instance of
    :class:`webtest.response.TestResponse`:
 
-   >>> response                         # doctest: -ELLIPSIS
-   <200 OK text/plain body='The view ... foo'/23>
+   >>> response
+   <200 OK text/plain body='Hello world!'>
 
 5. We can now verify that the response satisfies our expectations. In
    this case we test the response body in its entirety::

--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -6,11 +6,13 @@ Morepath app.  We assume you've already installed Morepath; if not,
 see the :doc:`installation` section.
 
 In order to carry out the test we'll use WebTest_, which you'll need
-to have installed:
+to have installed. You'll want to have a test automation tool like
+pytest_ too.  The :ref:`cookiecutter template <cookiecutter>` installs
+both for you, alternatively you can install both with pip:
 
 .. code-block:: sh
 
-  $ pip install webtest
+  $ pip install webtest pytest
 
 
 Testing a basic app

--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -1,0 +1,79 @@
+Automating the tests for your App
+=================================
+
+This an introductory guide to writing automated tests for your
+Morepath app.  We assume you've already installed Morepath; if not,
+see the :doc:`installation` section.
+
+In order to carry out the test we'll use WebTest_, which you'll need
+to have installed:
+
+.. code-block:: sh
+
+  $ pip install webtest
+
+
+Testing a basic app
+-------------------
+
+Let’s look at a minimal test of a basic app in Morepath:
+
+.. testcode::
+
+  def test_basic():
+      from morepath.tests.fixtures import basic
+      from webtest import TestApp as Client
+
+      c = Client(basic.app())
+
+      response = c.get('/foo')
+
+      assert response.body == b'The view for model: foo'
+
+You can save this function into a file and use a test automation tool
+like pytest_ to run it, or you can also invoke it as a regular Python
+function --- in this case a silent completion signifies success:
+
+  >>> test_basic()
+
+.. _pytest: https://pytest.org
+
+Let's now go through the test, line by line.
+
+1. We import the application that we want to test.  In this case we
+   are going to use one of the simple apps that are part of the test
+   suite distributed with Morepath:
+
+   >>> from morepath.tests.fixtures import basic
+
+   You can additionally use :func:`morepath.scan` if you are not sure
+   whether importing the app imports all the modules that are
+   required. In this particular instance, we know that importing
+   ``basic`` is sufficient and :func:`morepath.scan` is not needed.
+
+2. WebTest_ provides a class called :class:`webtest.app.TestApp`
+   that emulates a client for WSGI apps.  Lest we confuse it with the
+   app under test, we'll import it as ``Client``:
+
+   >>> from webtest import TestApp as Client
+
+3. We instantiate the app under test and the client:
+
+   >>> c = Client(basic.app())
+
+4. At this point we can use the client to query the app:
+
+   >>> response = c.get('/foo')
+
+   The returned response is an instance of
+   :class:`webtest.response.TestResponse`:
+
+   >>> response                         # doctest: -ELLIPSIS
+   <200 OK text/plain body='The view ... foo'/23>
+
+5. We can now verify that the response satisfies our expectations. In
+   this case we test the response body in its entirety::
+
+   >>> assert response.body == b'The view for model: foo'
+
+.. _webtest: https://webtest.readthedocs.org

--- a/doc/toc.rst
+++ b/doc/toc.rst
@@ -22,6 +22,7 @@ Table of Contents
    rest
    settings
    organizing_your_project
+   testing.rst
    upgrading
    directive_tricks
    logging


### PR DESCRIPTION
- As discussed in #203.
- Doctest tests the test used as example and the line-by-line walkthrough.
- Added intersphinx setup for webtest.
- Also mention `(cd doc/build; make doctest)` in the instructions on how to run doctests.