### PR TITLE
Phasing out autosetup

### DIFF
--- a/morepath/app.py
+++ b/morepath/app.py
@@ -210,10 +210,11 @@ class App(dectate.App):
 
         Mounted apps are discovered in breadth-first order.
 
-        This can be used as a more explicit alternative to
+        This method supersedes the function
         :func:`morepath.autocommit`.
 
         :return: the set of discovered apps.
+
         """
         discovery = set()
         found = {cls}

--- a/morepath/autosetup.py
+++ b/morepath/autosetup.py
@@ -20,9 +20,7 @@ def scan(package=None, ignore=None, handle_error=None):
     It scans by recursively importing the package and any modules
     in it, including any sub-packages.
 
-    Register any found directives with their app classes. It also
-    makes a list of :class:`App` subclasses that can be commited using
-    :func:`autocommit`.
+    Register any found directives with their app classes.
 
     :param package: The Python module or package to scan. Optional; if left
       empty case the calling package is scanned.

--- a/morepath/autosetup.py
+++ b/morepath/autosetup.py
@@ -6,7 +6,7 @@ are part of the public API.
 """
 
 import sys
-import dectate
+import warnings
 import importscan
 import importlib
 import pkg_resources
@@ -150,9 +150,14 @@ def autosetup(ignore=None):
       during scanning. Optional. If ommitted, ignore ``.test`` and
       ``.tests`` packages by default. See :func:`importscan.scan` for
       more details.
+
+    **Deprecated**: use the function :func:`morepath.autoscan`,
+    instead.  ``autosetup`` is now completely equivalent to it.
+
     """
+    warnings.warn("DEPRECATED. Autosetup is deprecated. "
+                  "Use autoscan instead.", DeprecationWarning)
     autoscan(ignore)
-    dectate.autocommit()
 
 
 def morepath_packages():

--- a/morepath/error.py
+++ b/morepath/error.py
@@ -22,9 +22,7 @@ from dectate import (ConfigError, ConflictError, TopologicalSortError,  # noqa
 
 # XXX is ConfigError the right base class?
 class AutoImportError(ConfigError):
-    """Raised when Morepath fails to import a module during
-    autoconfig/autosetup.
-    """
+    """Raised when Morepath fails to import a module during autoscan."""
 
     def __init__(self, module_name):
 
@@ -33,14 +31,12 @@ class AutoImportError(ConfigError):
             no such module could be imported.
 
             Make sure your module name matches the setup.py name, or use
-            autoscan directly::
+            morepath.scan directly::
 
-                import autoscan
                 import yourmodule
                 import morepath
 
-                autoscan.scan(yourmodule)
-                morepath.autosetup()
+                morepath.scan(yourmodule)
 
             For more information have a look at the 'configuration' docs.
         """

--- a/morepath/tests/test_autosetup.py
+++ b/morepath/tests/test_autosetup.py
@@ -53,18 +53,12 @@ def test_caller_package():
 
 def test_autosetup(monkeypatch):
     import sys
+
     for k in 'base.m', 'entrypoint.app', 'under_score.m':
         monkeypatch.delitem(sys.modules, k, raising=False)
-    monkeypatch.setattr('dectate.app.auto_app_classes', [], raising=False)
-    monkeypatch.setattr('dectate.app.global_configurables', [], raising=False)
 
-    autosetup()
+    pytest.deprecated_call(autosetup)
 
-    from entrypoint.app import App as EntrypointApp
-    assert EntrypointApp.is_committed()
-
-    from under_score.m import UnderscoreApp
-    assert UnderscoreApp.is_committed()
-
-    from base.m import App as BaseApp
-    assert BaseApp.is_committed()
+    assert 'base.m' in sys.modules
+    assert 'entrypoint.app' in sys.modules
+    assert 'under_score.m' in sys.modules

--- a/morepath/tests/test_scanning.py
+++ b/morepath/tests/test_scanning.py
@@ -39,7 +39,7 @@ def test_caller_package_in_init():
     assert self_scan.get_this_package() == self_scan
 
 
-def test_self_sanning_package():
+def test_self_scanning_package():
     from .fixtures.self_scan.app import App
 
     # Importing the app as we did above imports the definition only,


### PR DESCRIPTION
This addresses #405:

1. The function ``autosetup`` no longer invokes ``autocommit`` and now issues a deprecation warning.
2. The docstring of ``autosetup`` has a ``**Deprecated**`` notice.
3. The testing of ``autosetup`` has been updated.
4. References to ``autosetup`` and ``autocommit`` in docstrings have been updated.

The only remaining references to ``autosetup`` and ``autocommit`` in the code are:

1. The test of ``autosetup`` itself.
2. Publising in ``morepath/__init__.py``.

Sill to do:

* Remove ``autosetup`` and ``autocommit`` from the narrative docs.
* Marking the deprecation in CHANGES.txt.
