### PR TITLE
Cleanup of reify

### DIFF
--- a/morepath/reify.py
+++ b/morepath/reify.py
@@ -1,7 +1,7 @@
-# taken from pyramid.decorator
+# Originally taken from pyramid.decorator
 
 
-class reify(object):  # flake8: noqa
+class reify(object):
     """Cache a property.
 
     Use as a method decorator.  It operates almost exactly like the
@@ -34,10 +34,7 @@ class reify(object):  # flake8: noqa
     """
     def __init__(self, wrapped):
         self.wrapped = wrapped
-        try:
-            self.__doc__ = wrapped.__doc__
-        except:  # pragma: no cover
-            pass
+        self.__doc__ = wrapped.__doc__
 
     def __get__(self, inst, objtype=None):
         if inst is None:

--- a/morepath/reify.py
+++ b/morepath/reify.py
@@ -11,7 +11,9 @@ class reify(object):
     variable.  It is, in Python parlance, a non-data descriptor. An
     example:
 
-    .. code-block:: python
+    .. testcode::
+
+       from morepath import reify
 
        class Foo(object):
            @reify
@@ -21,16 +23,15 @@ class reify(object):
 
     And usage of Foo:
 
-    .. code-block:: python
+      >>> f = Foo()
+      >>> v = f.jammy
+      jammy called
+      >>> print(v)
+      1
+      >>> print f.jammy
+      1
+      >>> # jammy func not called the second time; it replaced itself with 1
 
-      f = Foo()
-      v = f.jammy
-      'jammy called'
-      print(v)
-      1
-      print f.jammy
-      1
-      # jammy func not called the second time; it replaced itself with 1
     """
     def __init__(self, wrapped):
         self.wrapped = wrapped

--- a/morepath/reify.py
+++ b/morepath/reify.py
@@ -13,13 +13,13 @@ class reify(object):
 
     .. testcode::
 
-       from morepath import reify
+      from morepath import reify
 
-       class Foo(object):
-           @reify
-           def jammy(self):
-               print('jammy called')
-               return 1
+      class Foo(object):
+          @reify
+          def jammy(self):
+              print('jammy called')
+              return 1
 
     And usage of Foo:
 

--- a/morepath/tests/test_reify.py
+++ b/morepath/tests/test_reify.py
@@ -27,5 +27,13 @@ def test__doc__copied():
     assert decorator.__doc__ == 'My doc'
 
 
+def test_no_doc():
+    def wrapped(inst):
+        pass
+
+    decorator = reify(wrapped)
+    assert decorator.__doc__ is None
+
+
 class Dummy(object):
     pass


### PR DESCRIPTION
1. Removed unnecessary (and untestable) try-except clause from reify, as all Python objects have a `__doc__` descriptor.

2. Testing the docstring.

3. Have consistent indentation in the docstring.

4. Removed the "flake8: noqa" flag from reify.