### PR TITLE
Added command line parsing to morepath.run

### DIFF
--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -20,8 +20,9 @@ You can save this as ``hello.py`` and then run it with Python:
 .. code-block:: console
 
   $ python hello.py
-  Running <__main__.App object at 0x10f8398d0> with wsgiref.simple_server on http://127.0.0.1:5000
-  Press Ctrl-C to stop.
+  Running <__main__.App object at 0x10f8398d0>
+  Listening on http://127.0.0.1:5000
+  Press Ctrl-C to stop...
 
 .. sidebar:: Making the server externally accessible
 
@@ -35,6 +36,12 @@ You can save this as ``hello.py`` and then run it with Python:
   argument of ``0.0.0.0`` to the ``morepath.run()`` function. ::
 
     morepath.run(App(), host='0.0.0.0')
+
+  Alternatively, you can specify ``0.0.0.0`` on the command line:
+
+  .. code-block:: console
+
+    $ python hello.py --host 0.0.0.0
 
   Note that the built-in web server is absolutely unsuitable for
   actual deployment. For those cases don't use ``morepath.run()`` at
@@ -50,6 +57,14 @@ You can save this as ``hello.py`` and then run it with Python:
 If you now go with a web browser to the URL given, you should see
 "Hello world!"  as expected. When you want to stop the server, just
 press control-C.
+
+Morepath uses port 5000 by default, and it might be the case that
+another service is already listening on that port.  If that happens
+you can specify a different port on the command line:
+
+.. code-block:: console
+
+  $ python hello.py --port 6000
 
 This application is a bit bigger than you might be used to in other
 web micro-frameworks. That's for a reason: Morepath is not geared to

--- a/morepath/run.py
+++ b/morepath/run.py
@@ -40,6 +40,11 @@ def run(
         callback=None):
     """Uses wsgiref.simple_server to run an application for debugging purposes.
 
+    By default, this function looks at the command line for arguments
+    specified with the ``--host`` or ``--port`` options. These
+    override the actual arguments passed to this function.  Use
+    ``ignore_cli=True`` to disable this behavior.
+
     Under non-exceptional circumstances this function never returns.
 
     Don't use this in production; use an external WSGI server instead,
@@ -54,6 +59,34 @@ def run(
     :param callback: function invoked after the creation of the server.
     :type callback: function(server) or None
     :return: never.
+
+    .. note::
+
+      Unless ``ignore_cli`` is true, this function provides a
+      full-featured command-line parser. Its help message describes
+      how to use it:
+
+      .. testcode::
+        :hide:
+
+        from morepath.run import make_parser
+        make_parser('<script name>', '127.0.0.1', 5000).print_help()
+
+      .. testoutput::
+
+        usage: <script name> [-h] [-p PORT] [-H HOST]
+
+        optional arguments:
+          -h, --help            show this help message and exit
+          -p PORT, --port PORT  TCP port on which to listen (default: 5000)
+          -H HOST, --host HOST  hostname or IP address on which to listen \
+(default:
+                                127.0.0.1)
+
+      The default values for the ``--port`` and ``--host`` options are
+      takend from the value of the arguments passed to
+      :func:`morepath.run`.
+
     """
     import errno
     import socket

--- a/morepath/run.py
+++ b/morepath/run.py
@@ -1,25 +1,82 @@
-from wsgiref.simple_server import make_server
+import sys
 
 
-def run(wsgi, host=None, port=None):  # pragma: no cover
-    """Uses wsgiref.simple_server to run application for debugging purposes.
+def make_parser(prog, default_host, default_port):
+    """Make a command-line parser with host and port arguments.
+
+    :param prog: the name of the program
+    :param default_host: the default value for the host argument
+    :param default_port: the default value for the port argument
+    :return: an instance of ArgumentParser
+    """
+    import argparse
+
+    def unsigned_short(s):
+        v = int(s)
+        if not 0 <= v <= 65536:
+            raise ValueError
+        return v
+    unsigned_short.__name__ = 'integer in 0..65535'
+
+    parser = argparse.ArgumentParser(
+        prog=prog,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        "-p", "--port", type=unsigned_short,
+        help="TCP port on which to listen")
+    parser.add_argument(
+        "-H", "--host",
+        help="hostname or IP address on which to listen")
+    parser.set_defaults(host=default_host, port=default_port)
+    return parser
+
+
+def run(
+        wsgi,
+        host='127.0.0.1',
+        port=5000,
+        prog=None,
+        ignore_cli=False,
+        callback=None):
+    """Uses wsgiref.simple_server to run an application for debugging purposes.
+
+    Under non-exceptional circumstances this function never returns.
 
     Don't use this in production; use an external WSGI server instead,
     for instance Apache mod_wsgi, Nginx wsgi, Waitress, Gunicorn.
 
-    :param wsgi: WSGI app.
-    :param host: hostname.
-    :param port: port.
+    :param callable wsgi: WSGI app.
+    :param str host: hostname or IP address on which to listen.
+    :param int port: TCP port on which to listen.
+    :param prog: the name of the program displayed by diagnostics and help.
+    :type prog: str or None
+    :param bool ignore_cli: whether to ignore ``sys.argv``.
+    :param callback: function invoked after the creation of the server.
+    :type callback: function(server) or None
+    :return: never.
     """
-    if host is None:
-        host = '127.0.0.1'
-    if port is None:
-        port = 5000
-    server = make_server(host, port, wsgi)
-    print("Running %s with wsgiref.simple_server on http://%s:%s" % (
-        wsgi, host, port))
-    print("Press Ctrl-C to stop.")
+    import socket
+    from wsgiref.simple_server import make_server
+
+    parser = make_parser(prog, host, port)
+    args = parser.parse_args([] if ignore_cli else None)
+
+    try:
+        server = make_server(args.host, args.port, wsgi)
+    except socket.error as ex:
+        parser.exit(ex.errno, '{}: {}: {}:{}\n'.format
+                    (parser.prog, ex, args.host, args.port))
+
+    if callback is not None:
+        callback(server)
+
+    print("Running {}".format(wsgi))
+    print("Listening on http://{}:{}".format(
+        server.server_address[0], server.server_port))
+    print("Press Ctrl-C to stop...")
     try:
         server.serve_forever()
     except KeyboardInterrupt:
         print("\nReceived keyboard interrupt.")
+
+    sys.exit(0)

--- a/morepath/run.py
+++ b/morepath/run.py
@@ -55,6 +55,7 @@ def run(
     :type callback: function(server) or None
     :return: never.
     """
+    import errno
     import socket
     from wsgiref.simple_server import make_server
 
@@ -64,8 +65,11 @@ def run(
     try:
         server = make_server(args.host, args.port, wsgi)
     except socket.error as ex:
+        hint = ""
+        if ex.errno == errno.EADDRINUSE and not ignore_cli:
+            hint = "\n  Use '--port PORT' to specify a different port.\n\n"
         parser.exit(ex.errno, '{}: {}: {}:{}\n'.format
-                    (parser.prog, ex, args.host, args.port))
+                    (parser.prog, ex, args.host, args.port) + hint)
 
     if callback is not None:
         callback(server)

--- a/morepath/tests/conftest.py
+++ b/morepath/tests/conftest.py
@@ -1,0 +1,43 @@
+import pytest
+
+
+@pytest.fixture
+def mockserver(monkeypatch):
+    """Make the server in wsgiref receive Ctrl-C as soon as it starts serving.
+
+    The fixture object provides these methods:
+        * set_argv(list): set the command-line arguments seen by morepath.run
+        * run(*args, **kw): run morepath.run and return the exit code
+
+    """
+    import sys
+    from wsgiref.simple_server import WSGIServer
+
+    def mock_serve_forever(self):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(WSGIServer, 'serve_forever', mock_serve_forever)
+    argv = ['script-name']
+    monkeypatch.setattr(sys, 'argv', argv)
+    return MockServer(argv)
+
+
+class MockServer(object):
+
+    def __init__(self, argv):
+        self.argv = argv
+
+    def set_argv(self, argv):
+        """Set the command-line arguments seen by morepath.run."""
+        self.argv.extend(argv)
+
+    def run(self, *args, **kw):
+        """Wrapper around morepath.run to catch SystemExit.
+
+        :return: the exit code."""
+        import morepath
+
+        with pytest.raises(SystemExit) as ex:
+            morepath.run(*args, **kw)
+
+        return ex.value.code

--- a/morepath/tests/test_run.py
+++ b/morepath/tests/test_run.py
@@ -1,0 +1,119 @@
+import morepath
+import re
+from .fixtures import basic
+import pytest
+
+
+def test_run_port_out_of_range(mockserver, capsys):
+    "Fail gracefully if the port is out of range."
+    mockserver.set_argv(['--port', '-3'])
+
+    assert mockserver.run(basic.app()) == 2
+
+    out, err = capsys.readouterr()
+
+    assert err == """\
+usage: script-name [-h] [-p PORT] [-H HOST]
+script-name: error: argument -p/--port: invalid integer in 0..65535 value: '-3'
+"""
+    assert out == ''
+
+
+def test_run_socketerror(mockserver, capsys):
+    """Fail gracefuly on a socket error.
+
+    In this case the error is triggered by listening on example.com.
+
+    """
+    mockserver.set_argv(['--host', 'example.com'])
+
+    assert mockserver.run(basic.app()) != 0
+
+    out, err = capsys.readouterr()
+
+    # The wording of the error message is system-specific.
+    assert re.match('script-name: .*: example.com:5000', err)
+    assert out == ''
+
+
+def test_run_defaults(mockserver, capsys):
+    "The arguments to makeserver form the defaults for the CLI."
+    mockserver.set_argv(['script-name', '--help'])
+
+    assert mockserver.run(basic.app(), host='localhost', port=80) == 0
+
+    out, err = capsys.readouterr()
+
+    assert err == ''
+    assert out == """\
+usage: script-name [-h] [-p PORT] [-H HOST]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -p PORT, --port PORT  TCP port on which to listen (default: 80)
+  -H HOST, --host HOST  hostname or IP address on which to listen (default:
+                        localhost)
+"""
+
+
+def test_run(mockserver, capsys):
+    "Run with a mocked server."
+    mockserver.set_argv(['--port', '0'])
+
+    assert mockserver.run(basic.app()) == 0
+
+    out, err = capsys.readouterr()
+
+    assert err == ''
+    assert re.match("""\
+Running <morepath.tests.fixtures.basic.app object at 0x[0-9a-f]+>
+Listening on http://127.0.0.1:\\d+
+Press Ctrl-C to stop...
+
+Received keyboard interrupt.""", out)
+
+
+def test_run_actual(capsys):
+    from threading import Thread
+
+    def query(url, completion_callback, response):
+        try:
+            from urllib import urlopen
+        except ImportError:
+            from urllib.request import urlopen
+        try:
+            response.append(urlopen(url).read())
+        except Exception as ex:
+            response.append(ex)
+        finally:
+            completion_callback()
+
+    response = []
+
+    def callback(server):
+        thread = Thread(target=query, args=(
+            'http://127.0.0.1:{}'.format(server.server_port),
+            server.shutdown, response))
+        thread.daemon = True
+        thread.start()
+
+    with pytest.raises(SystemExit) as ex:
+        morepath.run(
+            basic.app(),
+            port=0,
+            prog='script-name',
+            callback=callback,
+            ignore_cli=True)
+
+    assert ex.value.code == 0
+
+    assert response == [b'The root: ROOT']
+
+    out, err = capsys.readouterr()
+
+    assert re.match("""\
+Running <morepath.tests.fixtures.basic.app object at 0x[0-9a-f]+>
+Listening on http://127.0.0.1:\\d+
+Press Ctrl-C to stop...
+""", out)
+    assert re.match(r'127.0.0.1 - - \[.*?\] "GET / HTTP/1.[01]" 200 14', err)


### PR DESCRIPTION
This follows up on the discussion in #439:

* Added command-line parsing to ``morepath.run``. 
* Added tests for ``morepath.run``, which has now a richer behavior.
* The quickstart guide now mentions the possibility of specifying arguments on the command line.

Here is the new signature:

<dl class="function">
<dt id="morepath.run">
<code>morepath.run</code><span class="sig-paren">(</span><em>wsgi</em>, <em>host='127.0.0.1'</em>, <em>port=5000</em>, <em>prog=None</em>, <em>ignore_cli=False</em>, <em>callback=None</em><span class="sig-paren">)</span><a class="headerlink" href="#morepath.run" title="Permalink to this definition">¶</a></dt>
<dd><p>Uses wsgiref.simple_server to run an application for debugging purposes.</p>
<p>Under non-exceptional circumstances this function never returns.</p>
<p>Don&#8217;t use this in production; use an external WSGI server instead,
for instance Apache mod_wsgi, Nginx wsgi, Waitress, Gunicorn.</p>
<table class="docutils field-list" frame="void" rules="none">
<col class="field-name" />
<col class="field-body" />
<tbody valign="top">
<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
<li><strong>wsgi</strong> (<em>callable</em>) &#8211; WSGI app.</li>
<li><strong>host</strong> (<em>str</em>) &#8211; hostname or IP address on which to listen.</li>
<li><strong>port</strong> (<em>int</em>) &#8211; TCP port on which to listen.</li>
<li><strong>prog</strong> (<em>str or None</em>) &#8211; the name of the program displayed by diagnostics and help.</li>
<li><strong>ignore_cli</strong> (<em>bool</em>) &#8211; whether to ignore <code class="docutils literal"><span class="pre">sys.argv</span></code>.</li>
<li><strong>callback</strong> (<em>function(server) or None</em>) &#8211; function invoked after the creation of the server.</li>
</ul>
</td>
</tr>
<tr class="field-even field"><th class="field-name">Returns:</th><td class="field-body"><p class="first last">never.</p>
</td>
</tr>
</tbody>
</table>
</dd></dl>

Given how `morepath.run()` is used in the example applications, no change should be needed.

The supported command line arguments are:

```
usage: hello.py [-h] [-p PORT] [-H HOST]

optional arguments:
  -h, --help            show this help message and exit
  -p PORT, --port PORT  TCP port on which to listen (default: 5000)
  -H HOST, --host HOST  hostname or IP address on which to listen (default:
                        127.0.0.1)

```