### PR TITLE
Improved test isolation.

### DIFF
--- a/morepath/tests/test_autosetup.py
+++ b/morepath/tests/test_autosetup.py
@@ -19,9 +19,14 @@ def test_import():
     from ns import real2
     import under_score
 
-    assert sorted(list(morepath_packages()),
-                  key=lambda module: module.__name__) == [
-                      base, entrypoint, real, real2, sub, under_score]
+    # Pacakges to be ignored
+    import no_mp
+    from ns import nomp
+    import no_mp_sub
+
+    found = set(morepath_packages())
+    assert {base, entrypoint, real, real2, sub, under_score} <= found
+    assert {no_mp, nomp, no_mp_sub}.isdisjoint(found)
 
 
 def test_load_distribution():


### PR DESCRIPTION
When running the test suite of Morepath together with that of any of the extensions,  ``morepath_packages()`` will include those extensions too, so an equality test with a subset of the fixture packages will fail.

This Pull Request addresses that issue.