### PR TITLE
Add doctest tox environment for Python 3.4 and fix doctests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ env:
     - TOXENV=py33
     - TOXENV=py34
     - TOXENV=pypy
-    - TOXENV=docs
+    - TOXENV=docs27
+    - TOXENV=docs34
     - TOXENV=pep8
     - TOXENV=coverage
 install:

--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -81,8 +81,8 @@ Let's now go through the test, line by line.
    The returned response is an instance of
    :class:`webtest.response.TestResponse`:
 
-   >>> response
-   <200 OK text/plain body='Hello world!'>  # doctest: +SKIP
+   >>> response  # doctest: +SKIP
+   <200 OK text/plain body='Hello world!'>
 
 5. We can now verify that the response satisfies our expectations. In
    this case we test the response body in its entirety::

--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -82,7 +82,7 @@ Let's now go through the test, line by line.
    :class:`webtest.response.TestResponse`:
 
    >>> response
-   <200 OK text/plain body='Hello world!'>
+   <200 OK text/plain body='Hello world!'>  # doctest: +SKIP
 
 5. We can now verify that the response satisfies our expectations. In
    this case we test the response body in its entirety::

--- a/morepath/reify.py
+++ b/morepath/reify.py
@@ -28,7 +28,7 @@ class reify(object):
       jammy called
       >>> print(v)
       1
-      >>> print f.jammy
+      >>> print(f.jammy)
       1
       >>> # jammy func not called the second time; it replaced itself with 1
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy,py33,py34,pep8,coverage,docs
+envlist = py27,pypy,py33,py34,pep8,coverage,docs27,docs34
 [testenv]
 deps=
      -e{toxinidir}[test]
@@ -31,8 +31,15 @@ deps = {[testenv]deps}
 
 commands = py.test morepath --cov morepath {posargs}
 
-[testenv:docs]
-basepython = python2
+[testenv:docs27]
+basepython = python2.7
+deps = {[testenv]deps}
+       sphinx
+
+commands = sphinx-build -b doctest doc {envtmpdir}
+
+[testenv:docs34]
+basepython = python3.4
 deps = {[testenv]deps}
        sphinx
 


### PR DESCRIPTION
Two tests didn't pass.
In `reify.py` I added parentheses to the print statement.

The second failure is in testing.rst:
```
   >>> response
   <200 OK text/plain body='Hello world!'>
```
Python 2 returns here a string as in the example, but Python 3 returns a binary for the body:
```
   >>> response
   <200 OK text/plain body=b'Hello world!'>
```
@taschini Do you've an idea, how to fix this?