### PR TITLE
Remove unused imports and fix pep8 in core.py

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -72,6 +72,8 @@ CHANGES
 - Adding ``App.init_settings`` for pre-filling the settings registry with a
   python dictionary. This can be used to load the settings from a config file.
 
+- Remove unused imports and fix pep8 in core.py.
+
 0.14 (2016-04-26)
 =================
 

--- a/morepath/core.py
+++ b/morepath/core.py
@@ -20,24 +20,21 @@ subclass of :class:`morepath.App`. We do not guarantee we won't break
 your code with future version of Morepath if you do that, though.
 """
 
-import dectate
-import importscan
+import dectate  # noqa
+
 import re
 
 from reg import KeyIndex, ClassIndex
 from datetime import datetime, date
 from time import mktime, strptime
 
-from webob import Response as BaseResponse, BaseRequest
 from webob.exc import (
     HTTPException, HTTPNotFound, HTTPMethodNotAllowed,
     HTTPUnprocessableEntity, HTTPOk, HTTPRedirection, HTTPBadRequest)
 
-from . import directive  # install directives with App
+from . import directive  # install directives with App  # noqa
 from . import generic
 from .app import App
-from .view import View
-from .request import Request, Response
 from .converter import Converter, IDENTITY_CONVERTER
 
 
@@ -62,7 +59,7 @@ def model_not_found(self, request):
 @App.predicate(generic.view, name='name', default='', index=KeyIndex,
                after=model_predicate)
 def name_predicate(request):
-    """match name argument with request.view_name
+    """match name argument with request.view_name.
 
     Predicate for :meth:`morepath.App.view`.
     """
@@ -71,7 +68,7 @@ def name_predicate(request):
 
 @App.predicate_fallback(generic.view, name_predicate)
 def name_not_found(self, request):
-    """if name not matched, HTTP 404
+    """if name not matched, HTTP 404.
 
     Fallback for :meth:`morepath.App.view`.
     """
@@ -118,24 +115,21 @@ def body_model_unprocessable(self, request):
 
 @App.converter(type=int)
 def int_converter():
-    """Converter for int.
-    """
+    """Converter for int."""
     return Converter(int)
 
 
 @App.converter(type=type(u""))
 def unicode_converter():
-    """Converter for text.
-    """
+    """Converter for text."""
     return IDENTITY_CONVERTER
 
 
 # Python 2
-if type(u"") != type(""): # flake8: noqa
+if type(u"") != type(""):  # noqa
     @App.converter(type=type(""))
     def str_converter():
-        """Converter for non-text str.
-        """
+        """Converter for non-text str."""
         # XXX do we want to decode/encode unicode?
         return IDENTITY_CONVERTER
 
@@ -150,8 +144,7 @@ def date_encode(d):
 
 @App.converter(type=date)
 def date_converter():
-    """Converter for date.
-    """
+    """Converter for date."""
     return Converter(date_decode, date_encode)
 
 
@@ -165,8 +158,7 @@ def datetime_encode(d):
 
 @App.converter(type=datetime)
 def datetime_converter():
-    """Converter for datetime.
-    """
+    """Converter for datetime."""
     return Converter(datetime_decode, datetime_encode)
 
 
@@ -204,7 +196,7 @@ def excview_tween_factory(app, handler):
 
 @App.tween_factory(over=excview_tween_factory)
 def poisoned_host_header_protection_tween_factory(app, handler):
-    """ Protects Morepath applications against the most basic host header
+    """Protect Morepath applications against the most basic host header
     poisoning attacts.
 
     The regex approach has been copied from the Django project. To find more


### PR DESCRIPTION
In core.py was used `# flake8: noqa`, which prevented the whole file to be tested by flake8.
I changed this to `# noqa` which ignores only the specific line.
As a result I got many unused imports errors:
```python
import dectate
import importscan
from webob import Response as BaseResponse, BaseRequest
from . import directive  # install directives with App
from .view import View
from .request import Request, Response
```
I made flake8 ignore the `dectate` and `directive` import as they seem to be necessary and removed the other ones. I also fixed some minor flake8 warnings.

@faassen  Please check if this is ok or if I have removed to much imports. The tests are all passing.

This PR was split of PR #456.