### PR TITLE
Removed generic.identify.

### DIFF
--- a/morepath/directive.py
+++ b/morepath/directive.py
@@ -1110,8 +1110,6 @@ class IdentityPolicyAction(dectate.Composite):
         pass
 
     def actions(self, obj):
-        yield IdentityPolicyFunctionAction(generic.identify,
-                                           'identify'), obj
         yield IdentityPolicyFunctionAction(generic.remember_identity,
                                            'remember'), obj
         yield IdentityPolicyFunctionAction(generic.forget_identity,

--- a/morepath/generic.py
+++ b/morepath/generic.py
@@ -115,18 +115,6 @@ def settings():
     raise NotImplementedError  # pragma: nocoverage
 
 
-@reg.dispatch()
-def identify(request):
-    """Determine identity for request.
-
-    :param: a :class:`morepath.Request` instance.
-    :return: a :class:`morepath.Identity` instance or ``None`` if
-      no identity can be found. Can also return :data:`morepath.NO_IDENTITY`,
-      but ``None`` is converted automatically to this.
-    """
-    return None
-
-
 @reg.dispatch('identity')
 def verify_identity(identity):
     """Returns True if the claimed identity can be verified.

--- a/morepath/request.py
+++ b/morepath/request.py
@@ -75,7 +75,10 @@ class Request(BaseRequest):
         """
         # XXX annoying circular dependency
         from .authentication import NO_IDENTITY
-        result = generic.identify(self, lookup=self.lookup)
+        policy = self.app.config.identity_policy_registry.identity_policy
+        if policy is None:
+            return NO_IDENTITY
+        result = policy.identify(self)
         if result is None or result is NO_IDENTITY:
             return NO_IDENTITY
         if not generic.verify_identity(result, lookup=self.lookup):

--- a/morepath/tests/test_querytool.py
+++ b/morepath/tests/test_querytool.py
@@ -707,7 +707,7 @@ def test_identity_policy():
     r = objects(dectate.query_app(
         App, 'identity_policy'))
 
-    assert len(r) == 3
+    assert len(r) == 2
 
 
 def test_verify_identity():


### PR DESCRIPTION
This is still work in progress, an attempt to explore various possibilities related to #448.

In this experiment, the generic function ``identify`` is removed, and its logic is inlined at the invocation point.