### PR TITLE
A request class with implicit lookup

### DIFF
--- a/doc/compared.rst
+++ b/doc/compared.rst
@@ -210,12 +210,22 @@ each app has a separate reg registry. When you call a generic function
 Reg needs to know what registry to use to look it up. You can make
 this completely explicit by using a special ``lookup`` argument::
 
-  some_generic_function(doc, 3, lookup=app.lookup())
+  some_generic_function(doc, 3, lookup=app.lookup)
 
 That's all right in framework code, but doing that all the time is not
 very pretty in application code. For convenience, Morepath therefore
-sets up the current lookup implicitly as thread local state. Then you
-can simply write this::
+allows you to set up a :class:`morepath.Request` class that sets the
+current lookup implicitly as thread local state::
+
+  class ImplicitLookupRequest(morepath.Request):
+      def visit_app(self, app):
+          super(ImplicitLookupRequest, self).visit_app(app)
+          reg.implicit.lookup = app.lookup
+
+  class MyApp(morepath.App):
+      request_class = ImplicitLookupRequest
+
+Then you can simply write this::
 
   some_generic_function(doc, 3)
 

--- a/morepath/app.py
+++ b/morepath/app.py
@@ -19,7 +19,6 @@ import dectate
 
 from .request import Request
 from . import compat
-from .implicit import set_implicit
 from .reify import reify
 from . import generic
 from .path import PathInfo
@@ -79,9 +78,6 @@ class App(dectate.App):
         if not self.is_committed():
             self.commit()
         return self.config.reg_registry.caching_lookup
-
-    def set_implicit(self):
-        set_implicit(self.lookup)
 
     def request(self, environ):
         """Create a :class:`Request` given WSGI environment for this app.

--- a/morepath/publish.py
+++ b/morepath/publish.py
@@ -59,7 +59,7 @@ def resolve_model(request):
     :return: model object or ``None`` if not found.
     """
     app = request.app
-    app.set_implicit()
+    request.visit_app(app)
     while request.unconsumed:
         next = consume(app, request)
         if next is None:
@@ -69,7 +69,7 @@ def resolve_model(request):
         if not isinstance(next, App):
             return next
         # we found an app, make it the current app
-        next.set_implicit()
+        request.visit_app(next)
         next.parent = app
         request.app = next
         request.lookup = next.lookup

--- a/morepath/request.py
+++ b/morepath/request.py
@@ -11,6 +11,7 @@ from . import generic
 from .reify import reify
 from .traject import create_path, parse_path
 from .error import LinkError
+from .implicit import set_implicit
 
 SAME_APP = reg.Sentinel('SAME_APP')
 
@@ -129,11 +130,11 @@ class Request(BaseRequest):
 
         old_app = self.app
         old_lookup = self.lookup
-        app.set_implicit()
+        self.visit_app(app)
         self.app = app
         self.lookup = app.lookup
         result = view.func(obj, self)
-        old_app.set_implicit()
+        self.visit_app(old_app)
         self.app = old_app
         self.lookup = old_lookup
         return result
@@ -307,6 +308,9 @@ class Request(BaseRequest):
 
     def clear_after(self):
         self._after = []
+
+    def visit_app(self, app):
+        set_implicit(app.lookup)
 
 
 class Response(BaseResponse):

--- a/morepath/request.py
+++ b/morepath/request.py
@@ -310,6 +310,15 @@ class Request(BaseRequest):
         self._after = []
 
     def visit_app(self, app):
+        """Callback invoked when picking the application to handle a request.
+
+        Derived classes can redefine this method, typically ensuring
+        that its ``super`` is invoked.
+
+        :param app: the instance of :class:`morepath.App` selected to
+          handle a request.
+
+        """
         set_implicit(app.lookup)
 
 

--- a/morepath/tests/test_request_with_implicit_lookup.py
+++ b/morepath/tests/test_request_with_implicit_lookup.py
@@ -1,0 +1,139 @@
+import morepath
+import reg
+from webtest import TestApp as Client
+
+
+def setup_module(module):
+    morepath.disable_implicit()
+
+
+def setup_function(f):
+    reg.implicit.clear()
+
+
+class ImplicitLookupRequest(morepath.Request):
+    def visit_app(self, app):
+        super(ImplicitLookupRequest, self).visit_app(app)
+        reg.implicit.lookup = app.lookup
+
+
+def test_implicit_function():
+    class app(morepath.App):
+        request_class = ImplicitLookupRequest
+
+    @app.path(path='')
+    class Model(object):
+        def __init__(self):
+            pass
+
+    @reg.dispatch()
+    def one():
+        return "Default one"
+
+    @reg.dispatch()
+    def two():
+        return "Default two"
+
+    @app.function(one)
+    def one_impl():
+        return two()
+
+    @app.function(two)
+    def two_impl():
+        return "The real two"
+
+    @app.view(model=Model)
+    def default(self, request):
+        return one()
+
+    c = Client(app())
+
+    response = c.get('/')
+    assert response.body == b'The real two'
+
+
+def test_implicit_function_mounted():
+    class alpha(morepath.App):
+        request_class = ImplicitLookupRequest
+
+    class beta(morepath.App):
+        def __init__(self, id):
+            self.id = id
+
+    @alpha.mount(path='mounted/{id}', app=beta)
+    def mount_beta(id):
+        return beta(id=id)
+
+    class AlphaRoot(object):
+        pass
+
+    class Root(object):
+        def __init__(self, id):
+            self.id = id
+
+    @alpha.path(path='/', model=AlphaRoot)
+    def get_alpha_root():
+        return AlphaRoot()
+
+    @beta.path(path='/', model=Root)
+    def get_root(app):
+        return Root(app.id)
+
+    @reg.dispatch()
+    def one():
+        return "Default one"
+
+    @reg.dispatch()
+    def two():
+        return "Default two"
+
+    @beta.function(one)
+    def one_impl():
+        return two()
+
+    @beta.function(two)
+    def two_impl():
+        return "The real two"
+
+    @alpha.view(model=AlphaRoot)
+    def alpha_default(self, request):
+        return one()
+
+    @beta.view(model=Root)
+    def default(self, request):
+        return "View for %s, message: %s" % (self.id, one())
+
+    c = Client(alpha())
+
+    response = c.get('/mounted/1')
+    assert response.body == b'View for 1, message: The real two'
+
+    response = c.get('/')
+    assert response.body == b'Default one'
+
+
+def test_no_implicit_lookup():
+
+    class app(morepath.App):
+        pass
+
+    @app.path(path='')
+    class Model(object):
+        def __init__(self):
+            pass
+
+    @reg.dispatch()
+    def one():
+        return "default one"
+
+    @app.view(model=Model)
+    def default(self, request):
+        try:
+            return one()
+        except reg.NoImplicitLookupError:
+            return "No implicit found"
+
+    c = Client(app())
+
+    response = c.get('/')
+    assert response.body == b'No implicit found'


### PR DESCRIPTION
The purpose of this PR is to provide an alternative to the ``enable_implicit``, ``disable_implicit`` functions, which we want to deprecate (#455).

This PR achieves that as follows:

1. A small redesign of the interface between the ``App`` and ``Request`` classes. Where we used to have

   ``app.set_implicit()``

   we now have

   ``request.visit_app(app)``

2. The current implementation of ``request.visit_app(app)`` is identical to the old ``app.set_implicit`` to ensure API consistency. In version 0.16, when ``enable_implicit`` and ``disable_implicit`` will be removed from the API, the default will be to do nothing.

3. In the tests I verify that using a small class, ``ImplicitLookupRequest``, as ``App.request_class`` perfectly reproduces the behavior that you'd get with ``enable_implicit``.  This is done by redefining the ``visit_app`` method. These tests are in ``test_request_with_implicit_lookup.py``, which basically is a copy of ``test_implicit.py`` adapted to ``ImplicitLookupRequest`` instead of ``enable_implicit``.

4. In the deprecation notices we can then say that if your ``@App.functions`` call other generic functions that are invoked using implicit lookup then you must either use a request class like ``ImplicitLookupRequest`` in your top-level app or modify the invocations and signatures of the generic functions to allow for the lookup argument to be explicitly passed around. 

For all practical purposes, this PR allows the transition to a 0.16 version where Reg lookup is explicit by default, but if you actually need implicit lookup because of your ``@App.function``s, you can have that.

Questions:

1. Do we want to provide ``ImplicitLookupRequest`` class as part of the API, or do we just describe it in the docs?

2. Do we want perhaps to provide ``ImplicitLookupRequest`` (and perhaps an ``ImplicitLookupApp``) in a separate extension (a bit like ``more.static`` does)?
