### PR TITLE
Reorganized the TOC of the docs into a hierarchy

### DIFF
--- a/doc/advanced-topics.rst
+++ b/doc/advanced-topics.rst
@@ -1,0 +1,16 @@
+Advanced Topics
+===============
+
+A selection of special topics to get the best out of your Morepath
+project.
+
+
+.. toctree::
+   :maxdepth: 2
+
+   organizing_your_project
+   building_large_applications
+   rest
+   testing.rst
+   directive_tricks
+   config_query

--- a/doc/api-reference.rst
+++ b/doc/api-reference.rst
@@ -1,0 +1,10 @@
+Reference
+=========
+
+In this section you can look up a specific function, class, or method.
+
+.. toctree::
+   :maxdepth: 2
+
+   api
+   extension_api

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -210,7 +210,7 @@ latex_documents = [
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+latex_use_parts = True
 
 # If true, show page references after internal links.
 #latex_show_pagerefs = False

--- a/doc/contributor-guide.rst
+++ b/doc/contributor-guide.rst
@@ -1,0 +1,12 @@
+Contributor Guide
+=================
+
+If you want to contribute to the project, this part of the
+documentation is for you.
+
+.. toctree::
+   :maxdepth: 2
+
+   developing
+   design
+   implementation

--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -1,0 +1,17 @@
+Getting Started
+===============
+
+If you are new to Morepath, you'll find here a few resources that can
+help you get up to speed right away.
+
+.. toctree::
+   :maxdepth: 2
+
+   index
+   quickstart
+   community
+   examples
+   installation
+   superpowers
+   compared
+   web

--- a/doc/project-history.rst
+++ b/doc/project-history.rst
@@ -1,0 +1,11 @@
+History
+=======
+
+The change log and how to use it.
+
+.. toctree::
+   :maxdepth: 2
+
+   history
+   changes
+   upgrading

--- a/doc/toc.rst
+++ b/doc/toc.rst
@@ -1,45 +1,15 @@
 Documentation
 =============
 
-Table of Contents
------------------
-
 .. toctree::
    :maxdepth: 2
 
-   index
-   quickstart
-   community
-   examples
-   installation
-   superpowers
-   web
-   paths_and_linking
-   views
-   templates
-   configuration
-   json
-   security
-   rest
-   settings
-   organizing_your_project
-   testing.rst
-   upgrading
-   directive_tricks
-   logging
-   app_reuse
-   building_large_applications
-   tweens
-   more.static
-   config_query
-   api
-   extension_api
-   implementation
-   compared
-   design
-   developing
-   changes
-   history
+   getting-started
+   user-guide
+   advanced-topics
+   api-reference
+   contributor-guide
+   project-history
 
 
 Indices and tables
@@ -48,4 +18,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/doc/user-guide.rst
+++ b/doc/user-guide.rst
@@ -1,0 +1,20 @@
+User Guide
+==========
+
+You'll find in this section a tour of the features of Morepath, and
+how to use them to develop your web application.
+
+.. toctree::
+   :maxdepth: 2
+
+   paths_and_linking
+   views
+   templates
+   configuration
+   json
+   security
+   settings
+   logging
+   app_reuse
+   tweens
+   more.static


### PR DESCRIPTION
I actually got around to reorganizing the TOC into a hierarchical structure. It can be previewed as:

* http://taschini-morepath.readthedocs.io

The Latex-generated PDF file is structured accordingly.