### PR TITLE
Remove deprecated functions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,43 @@ CHANGES
 0.16 (unreleased)
 =================
 
-- Nothing changed yet.
+Removal & Deprecations
+----------------------
+
+- **Removed**: ``morepath.remember_identity`` is removed from the
+  Morepath API.
+
+  Use ::
+
+    request.app.remember_identity(response, request, identity)
+
+  Instead of ::
+
+    remember_identity(response, request, identity, lookup=request.lookup)
+
+- **Removed**: ``morepath.forget_identity`` is removed from the
+  Morepath API.
+
+  Use ::
+
+    request.app.forget_identity(response, request)
+
+  Instead of ::
+
+    morepath.forget_identity(response, request, lookup=request.lookup)
+
+- **Removed** ``morepath.settings`` is removed from the Morepath API.
+
+  Use the ``morepath.App.settings`` property instead.
+
+- **Removed** ``morepath.enable_implicit`` and
+  ``morepath.disable_implicit`` are both removed from the Morepath API.
+
+  You no longer need to choose between implicit or explicit lookup for
+  generic functions, as the generic functions that are part of the API
+  have all been removed.  Generic functions decorated by
+  ``morepath.App.function`` can use implicit lookup by default.
+
 
 
 0.15 (2016-07-18)

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -33,10 +33,6 @@ API
 .. autoclass:: morepath.Identity
   :members:
 
-.. autofunction:: morepath.remember_identity(response, request, identity)
-
-.. autofunction:: morepath.forget_identity(response, request)
-
 .. autoclass:: morepath.IdentityPolicy
   :members:
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -45,10 +45,6 @@ API
 .. autoclass:: morepath.Converter
   :members:
 
-.. autofunction:: morepath.enable_implicit
-
-.. autofunction:: morepath.disable_implicit
-
 ``morepath.error`` -- exception classes
 ---------------------------------------
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -18,8 +18,6 @@ API
 
 .. autofunction:: run
 
-.. autofunction:: settings()
-
 .. autoclass:: Request
   :members:
 

--- a/morepath/__init__.py
+++ b/morepath/__init__.py
@@ -26,7 +26,3 @@ from .authentication import Identity, IdentityPolicy, NO_IDENTITY
 from .converter import Converter
 from .reify import reify
 from .run import run
-
-from reg import implicit
-
-implicit.initialize(None)

--- a/morepath/__init__.py
+++ b/morepath/__init__.py
@@ -20,7 +20,7 @@ from .core import (excview_tween_factory as EXCVIEW,
     model_predicate, name_predicate, request_method_predicate,
     body_model_predicate)
 from .core import body_model_predicate as LAST_VIEW_PREDICATE
-from .generic import remember_identity, forget_identity, settings
+from .generic import remember_identity, forget_identity
 from .view import render_json, render_html, redirect
 from .request import Request, Response
 from .autosetup import scan, autoscan

--- a/morepath/__init__.py
+++ b/morepath/__init__.py
@@ -14,7 +14,6 @@ report an issue about it on the Morepath issue tracker.
 
 from dectate import commit
 from .app import App
-from .implicit import enable_implicit, disable_implicit
 from .core import (excview_tween_factory as EXCVIEW,
     poisoned_host_header_protection_tween_factory as HOST_HEADER_PROTECTION,
     model_predicate, name_predicate, request_method_predicate,

--- a/morepath/__init__.py
+++ b/morepath/__init__.py
@@ -20,7 +20,6 @@ from .core import (excview_tween_factory as EXCVIEW,
     model_predicate, name_predicate, request_method_predicate,
     body_model_predicate)
 from .core import body_model_predicate as LAST_VIEW_PREDICATE
-from .generic import remember_identity, forget_identity
 from .view import render_json, render_html, redirect
 from .request import Request, Response
 from .autosetup import scan, autoscan

--- a/morepath/app.py
+++ b/morepath/app.py
@@ -196,12 +196,7 @@ class App(dectate.App):
 
     @property
     def settings(self):
-        """Returns the settings bound to this app.
-
-        Works the same way as :func:`morepath.generic.settings`. Unlike calling
-        ``morepath.settings`` however, this property does not rely on the
-        global lookup.
-        """
+        """Returns the settings bound to this app."""
         return self.config.setting_registry
 
     @classmethod

--- a/morepath/authentication.py
+++ b/morepath/authentication.py
@@ -10,9 +10,6 @@ directive.
 See also :class:`morepath.directive.IdentityPolicyRegistry`
 """
 
-import warnings
-from functools import wraps
-
 from reg import mapply
 
 from .cachingreg import RegRegistry
@@ -73,26 +70,7 @@ class IdentityPolicyRegistry(object):
                 factory,
                 settings=self.setting_registry)
         func = getattr(identity_policy, name)
-        message = (
-            "DEPRECATED. morepath.{0}_identity is deprecated. "
-            "Use the morepath.App.{0}_identity method instead.".format(name))
-        if name == 'remember':
-
-            @wraps(func)
-            def wrapper(response, request, identity):
-                warnings.warn(message, DeprecationWarning)
-                return func(response, request, identity)
-
-        elif name == 'forget':
-
-            @wraps(func)
-            def wrapper(response, request):
-                warnings.warn(message, DeprecationWarning)
-                return func(response, request)
-
-        else:
-            wrapper = func
-        self.reg_registry.register_function(dispatch, wrapper)
+        self.reg_registry.register_function(dispatch, func)
 
 
 class Identity(object):

--- a/morepath/directive.py
+++ b/morepath/directive.py
@@ -81,19 +81,6 @@ class SettingAction(dectate.Action):
     def perform(self, obj, reg_registry, setting_registry):
         setting_registry.register_setting(self.section, self.name, obj)
 
-    @staticmethod
-    def after(reg_registry, setting_registry):
-        import warnings
-
-        def f():
-            warnings.warn(
-                "DEPRECATED. morepath.settings is deprecated. "
-                "Use the morepath.App.settings property instead.",
-                DeprecationWarning)
-            return setting_registry
-
-        reg_registry.register_function(generic.settings, f)
-
 
 class SettingValue(object):
     def __init__(self, value):

--- a/morepath/directive.py
+++ b/morepath/directive.py
@@ -1099,10 +1099,6 @@ class IdentityPolicyAction(dectate.Composite):
     def actions(self, obj):
         yield IdentityPolicyFunctionAction(generic.identify,
                                            'identify'), obj
-        yield IdentityPolicyFunctionAction(generic.remember_identity,
-                                           'remember'), obj
-        yield IdentityPolicyFunctionAction(generic.forget_identity,
-                                           'forget'), obj
 
 
 @App.directive('verify_identity')

--- a/morepath/generic.py
+++ b/morepath/generic.py
@@ -6,10 +6,6 @@ The functions are made pluggable by the use of the
 decorators. Morepath's configuration function uses this to register
 implementations using :meth:`reg.Registry.register_function`.
 
-:func:`morepath.remember_identity`, and
-:func:`morepath.forget_identity`, currently exported to the public
-API, are now deprecated.
-
 """
 import reg
 from webob.exc import HTTPNotFound
@@ -122,34 +118,6 @@ def verify_identity(identity):
       can be verified so this returns ``False``.
     """
     return False
-
-
-@reg.dispatch()
-def remember_identity(response, request, identity):
-    """Modify response so that identity is remembered by client.
-
-    **Deprecated**: use the method
-    :meth:`morepath.App.remember_identity` instead.
-
-    :param response: :class:`morepath.Response` to remember identity on.
-    :param request: :class:`morepath.Request`
-    :param identity: :class:`morepath.Identity`
-
-    """
-    raise NotImplementedError  # pragma: nocoverage
-
-
-@reg.dispatch()
-def forget_identity(response, request):
-    """Modify response so that identity is forgotten by client.
-
-    **Deprecated**: use the method
-    :meth:`morepath.App.forget_identity` instead.
-
-    :param response: :class:`morepath.Response` to forget identity on.
-    :param request: :class:`morepath.Request`
-    """
-    raise NotImplementedError  # pragma: nocoverage
 
 
 @reg.dispatch('identity', 'obj',

--- a/morepath/generic.py
+++ b/morepath/generic.py
@@ -6,9 +6,9 @@ The functions are made pluggable by the use of the
 decorators. Morepath's configuration function uses this to register
 implementations using :meth:`reg.Registry.register_function`.
 
-:func:`morepath.remember_identity`, :func:`morepath.forget_identity`
-and :func:`morepath.settings`, currently exported to the public API,
-are now deprecated.
+:func:`morepath.remember_identity`, and
+:func:`morepath.forget_identity`, currently exported to the public
+API, are now deprecated.
 
 """
 import reg
@@ -96,23 +96,6 @@ def view(obj, request):
       :class:`webob.exc.HTTPNotFound` if view cannot be found.
     """
     return HTTPNotFound()
-
-
-@reg.dispatch()
-def settings():
-    """Return current settings object.
-
-    In it are sections, and inside of the sections are the setting values.
-    If there is a ``logging`` section and a ``loglevel`` setting in it,
-    this is how you would access it::
-
-      settings().logging.loglevel
-
-    **Deprecated**: use the property :attr:`morepath.App.settings` instead.
-
-    :return: current settings object for this app.
-    """
-    raise NotImplementedError  # pragma: nocoverage
 
 
 @reg.dispatch()

--- a/morepath/implicit.py
+++ b/morepath/implicit.py
@@ -1,15 +1,8 @@
-"""Track whether we want implicit lookup behavior.
-
-You can control this behavior from here.
-:func:`morepath.enable_implicit` and :func:`morepath.disable_implicit`,
-currently exported to the public API, are now deprecated.
-
+"""Provide support for implicit lookup behavior.
 """
 
 from reg import implicit
-import warnings
-
-_implicit_enabled = True
+implicit.initialize(None)
 
 
 def set_implicit(lookup):
@@ -17,50 +10,4 @@ def set_implicit(lookup):
 
     :lookup: :class:`reg.Lookup` instance.
     """
-    if _implicit_enabled:
-        implicit.lookup = lookup
-
-
-def enable_implicit():
-    """Enable implicit Reg lookups.
-
-    By default this is turned on. This means Morepath does not require
-    a ``lookup`` argument when you use generic functions such as
-    :func:`morepath.settings`. This lookup argument is implicitly
-    determined from the application that is mounted.
-
-    **Deprecated** You no longer need to choose between implicit or
-    explicit lookup for generic functions, as the generic functions
-    that are part of the API have all been deprecated.
-
-    """
-    global _implicit_enabled
-    warnings.warn(
-        "DEPRECATED. morepath.enable_implicit is deprecated. "
-        "Choosing implicit/explicit lookup is no longer relevant.",
-        DeprecationWarning)
-    _implicit_enabled = True
-
-
-def disable_implicit():
-    """Disable implicit Reg lookups.
-
-    The Morepath core itself does not rely on any implicit behavior,
-    and it is therefore disabled for many of the tests.
-
-    How to disable implicit lookups for all tests in a module::
-
-       def setup_module(module):
-           morepath.disable_implicit()
-
-    **Deprecated** You no longer need to choose between implicit or
-    explicit lookup for generic functions, as the generic functions
-    that are part of the API have all been deprecated.
-
-    """
-    global _implicit_enabled
-    warnings.warn(
-        "DEPRECATED. morepath.disable_implicit is deprecated. "
-        "Choosing implicit/explicit lookup is no longer relevant.",
-        DeprecationWarning)
-    _implicit_enabled = False
+    implicit.lookup = lookup

--- a/morepath/settings.py
+++ b/morepath/settings.py
@@ -14,8 +14,7 @@ class SettingRegistry(object):
     attributes.
 
     This settings registry is exposed through
-    :attr:`morepath.App.settings` as well as the
-    :func:`morepath.settings` function.
+    :attr:`morepath.App.settings`.
     """
     def register_setting(self, section_name, setting_name, func):
         """Register a setting.

--- a/morepath/tests/test_autosetup.py
+++ b/morepath/tests/test_autosetup.py
@@ -7,11 +7,6 @@ import morepath
 import pytest
 
 
-def setup_module(module):
-    with pytest.deprecated_call():
-        morepath.disable_implicit()
-
-
 def test_import():
     import base
     import sub

--- a/morepath/tests/test_cleanup.py
+++ b/morepath/tests/test_cleanup.py
@@ -2,10 +2,6 @@ import morepath
 import dectate
 
 
-def setup_module(module):
-    morepath.disable_implicit()
-
-
 def test_cleanup():
     class App(morepath.App):
         pass

--- a/morepath/tests/test_defer_links.py
+++ b/morepath/tests/test_defer_links.py
@@ -4,10 +4,6 @@ from morepath.error import LinkError, ConflictError
 import pytest
 
 
-def setup_module(module):
-    morepath.disable_implicit()
-
-
 def test_defer_links():
 
     class Root(morepath.App):

--- a/morepath/tests/test_directive.py
+++ b/morepath/tests/test_directive.py
@@ -12,10 +12,6 @@ import pytest
 from webtest import TestApp as Client
 
 
-def setup_module(module):
-    morepath.disable_implicit()
-
-
 def test_basic():
     c = Client(basic.app())
 

--- a/morepath/tests/test_excview.py
+++ b/morepath/tests/test_excview.py
@@ -4,10 +4,6 @@ from webtest import TestApp as Client
 import pytest
 
 
-def setup_module(module):
-    morepath.disable_implicit()
-
-
 def test_404_http_exception():
     class app(morepath.App):
         pass

--- a/morepath/tests/test_extend.py
+++ b/morepath/tests/test_extend.py
@@ -2,10 +2,6 @@ import morepath
 from webtest import TestApp as Client
 
 
-def setup_module(module):
-    morepath.disable_implicit()
-
-
 def test_extends():
     class App(morepath.App):
         pass

--- a/morepath/tests/test_implicit.py
+++ b/morepath/tests/test_implicit.py
@@ -1,10 +1,11 @@
 import morepath
+from morepath.implicit import enable_implicit, disable_implicit
 import reg
 from webtest import TestApp as Client
 
 
 def setup_module(module):
-    morepath.enable_implicit()
+    enable_implicit()
 
 
 def setup_function(f):
@@ -107,7 +108,7 @@ def test_implicit_function_mounted():
 
 
 def test_implicit_disabled():
-    morepath.disable_implicit()
+    disable_implicit()
 
     class app(morepath.App):
         pass

--- a/morepath/tests/test_implicit.py
+++ b/morepath/tests/test_implicit.py
@@ -1,11 +1,6 @@
 import morepath
-from morepath.implicit import enable_implicit, disable_implicit
 import reg
 from webtest import TestApp as Client
-
-
-def setup_module(module):
-    enable_implicit()
 
 
 def setup_function(f):
@@ -105,31 +100,3 @@ def test_implicit_function_mounted():
 
     response = c.get('/')
     assert response.body == b'Default one'
-
-
-def test_implicit_disabled():
-    disable_implicit()
-
-    class app(morepath.App):
-        pass
-
-    @app.path(path='')
-    class Model(object):
-        def __init__(self):
-            pass
-
-    @reg.dispatch()
-    def one():
-        return "default one"
-
-    @app.view(model=Model)
-    def default(self, request):
-        try:
-            return one()
-        except reg.NoImplicitLookupError:
-            return "No implicit found"
-
-    c = Client(app())
-
-    response = c.get('/')
-    assert response.body == b'No implicit found'

--- a/morepath/tests/test_init_settings.py
+++ b/morepath/tests/test_init_settings.py
@@ -5,10 +5,6 @@ from morepath.error import ConflictError
 from morepath.tests.fixtures.config import settings as settings_file
 
 
-def setup_module(module):
-    morepath.disable_implicit()
-
-
 def test_init_settings():
 
     settings_dict = {

--- a/morepath/tests/test_internal.py
+++ b/morepath/tests/test_internal.py
@@ -2,10 +2,6 @@ import morepath
 from webtest import TestApp as Client
 
 
-def setup_module(module):
-    morepath.disable_implicit()
-
-
 def test_internal():
     class app(morepath.App):
         pass

--- a/morepath/tests/test_json_obj.py
+++ b/morepath/tests/test_json_obj.py
@@ -2,10 +2,6 @@ import morepath
 from webtest import TestApp as Client
 
 
-def setup_module(module):
-    morepath.disable_implicit()
-
-
 def test_json_obj_dump():
     class app(morepath.App):
         pass

--- a/morepath/tests/test_model.py
+++ b/morepath/tests/test_model.py
@@ -11,10 +11,6 @@ from morepath.publish import consume as traject_consume
 import webob
 
 
-def setup_module(module):
-    morepath.disable_implicit()
-
-
 def consume(mount, path, parameters=None):
     if parameters:
         path += '?' + urlencode(parameters, True)

--- a/morepath/tests/test_mount_directive.py
+++ b/morepath/tests/test_mount_directive.py
@@ -4,10 +4,6 @@ from webtest import TestApp as Client
 import pytest
 
 
-def setup_module():
-    morepath.disable_implicit()
-
-
 def test_model_mount_conflict():
     class app(morepath.App):
         pass

--- a/morepath/tests/test_path_directive.py
+++ b/morepath/tests/test_path_directive.py
@@ -11,10 +11,6 @@ from webtest import TestApp as Client
 import pytest
 
 
-def setup_module(module):
-    morepath.disable_implicit()
-
-
 def test_simple_path_one_step():
     class app(morepath.App):
         pass

--- a/morepath/tests/test_predicate.py
+++ b/morepath/tests/test_predicate.py
@@ -5,10 +5,6 @@ from morepath.error import ConfigError
 import pytest
 
 
-def setup_module(module):
-    morepath.disable_implicit()
-
-
 def test_dispatch():
     class App(morepath.App):
         pass

--- a/morepath/tests/test_predicates.py
+++ b/morepath/tests/test_predicates.py
@@ -6,10 +6,6 @@ from morepath import generic
 from reg import KeyIndex
 
 
-def setup_module(module):
-    morepath.disable_implicit()
-
-
 def test_view_predicates():
     class app(App):
         pass

--- a/morepath/tests/test_publish.py
+++ b/morepath/tests/test_publish.py
@@ -10,10 +10,6 @@ from webtest import TestApp as Client
 import pytest
 
 
-def setup_module(module):
-    morepath.disable_implicit()
-
-
 def get_environ(path, **kw):
     return webob.Request.blank(path, **kw).environ
 

--- a/morepath/tests/test_querytool.py
+++ b/morepath/tests/test_querytool.py
@@ -707,7 +707,7 @@ def test_identity_policy():
     r = objects(dectate.query_app(
         App, 'identity_policy'))
 
-    assert len(r) == 3
+    assert len(r) == 1
 
 
 def test_verify_identity():

--- a/morepath/tests/test_scenario.py
+++ b/morepath/tests/test_scenario.py
@@ -5,10 +5,6 @@ import morepath
 from webtest import TestApp as Client
 
 
-def setup_module(module):
-    morepath.disable_implicit()
-
-
 def test_scenario():
     morepath.scan(scenario)
 

--- a/morepath/tests/test_security.py
+++ b/morepath/tests/test_security.py
@@ -13,10 +13,6 @@ except ImportError:
     from http.cookiejar import CookieJar
 
 
-def setup_module(module):
-    morepath.disable_implicit()
-
-
 def test_no_permission():
     class app(morepath.App):
         pass

--- a/morepath/tests/test_security.py
+++ b/morepath/tests/test_security.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import pytest
-
 import morepath
 from morepath.request import Response
 from morepath import generic
@@ -252,11 +250,9 @@ def test_false_verify_identity():
     @app.view(model=Model, name='log_in')
     def log_in(self, request):
         response = Response()
-        with pytest.deprecated_call():
-            generic.remember_identity(
-                response, request,
-                Identity(userid='user', payload='Amazing'),
-                lookup=request.lookup)
+        request.app.remember_identity(
+            response, request,
+            Identity(userid='user', payload='Amazing'))
         return response
 
     @app.identity_policy()

--- a/morepath/tests/test_setting_directive.py
+++ b/morepath/tests/test_setting_directive.py
@@ -139,9 +139,7 @@ def test_app_section_settings_conflict():
         dectate.commit(app)
 
 
-def test_settings_function():
-    morepath.enable_implicit()
-
+def test_settings_property_in_view():
     class app(morepath.App):
         pass
 
@@ -158,17 +156,7 @@ def test_settings_function():
     def default(self, request):
         return request.app.settings.section.name
 
-    @app.view(model=Model, name='generic')
-    def generic(self, request):
-        with pytest.deprecated_call():
-            return morepath.settings().section.name
-
-    dectate.commit(app)
-
     c = Client(app())
 
     response = c.get('/')
-    assert response.body == b'LAH'
-
-    response = c.get('/generic')
     assert response.body == b'LAH'

--- a/morepath/tests/test_setting_directive.py
+++ b/morepath/tests/test_setting_directive.py
@@ -5,10 +5,6 @@ import pytest
 from webtest import TestApp as Client
 
 
-def setup_module(module):
-    morepath.disable_implicit()
-
-
 def test_settings_property():
     class App(morepath.App):
         pass

--- a/morepath/tests/test_template.py
+++ b/morepath/tests/test_template.py
@@ -1,4 +1,3 @@
-import morepath
 from morepath.error import ConfigError
 from webtest import TestApp as Client
 import pytest
@@ -6,10 +5,6 @@ from .fixtures import (
     template, template_override, template_override_implicit,
     template_unknown_extension, template_unknown_extension_no_render,
     template_no_template_directories, template_override_under)
-
-
-def setup_module(module):
-    morepath.disable_implicit()
 
 
 def test_template_fixture():

--- a/morepath/tests/test_traject.py
+++ b/morepath/tests/test_traject.py
@@ -13,10 +13,6 @@ from webob.exc import HTTPBadRequest
 import webob
 
 
-def setup_module(module):
-    morepath.disable_implicit()
-
-
 class Root(object):
     pass
 

--- a/morepath/tests/test_tween.py
+++ b/morepath/tests/test_tween.py
@@ -5,10 +5,6 @@ import pytest
 from webtest import TestApp as Client
 
 
-def setup_module(module):
-    morepath.disable_implicit()
-
-
 def test_tween_sorting_no_tweens():
     reg = TweenRegistry()
     assert reg.sorted_tween_factories() == []

--- a/morepath/tests/test_view_directive.py
+++ b/morepath/tests/test_view_directive.py
@@ -7,10 +7,6 @@ import pytest
 from morepath.core import request_method_predicate
 
 
-def setup_module(module):
-    morepath.disable_implicit()
-
-
 def test_view_get_only():
     class App(morepath.App):
         pass


### PR DESCRIPTION
This pull request removes the functions that have been deprecated in Morepath 0.15. 
It closes #454.