### PR TITLE
Have App.permission_rule accept a function with three or four arguments.

### DIFF
--- a/morepath/directive.py
+++ b/morepath/directive.py
@@ -31,7 +31,9 @@ from :mod:`morepath.directive`.
 
 import os
 import dectate
+import reg
 
+from functools import wraps
 from .app import App
 from .cachingreg import RegRegistry
 from .authentication import Identity, NoIdentity, IdentityPolicyRegistry
@@ -483,8 +485,13 @@ class PermissionRuleAction(dectate.Action):
         return (self.model, self.permission, self.identity)
 
     def perform(self, obj, reg_registry):
+        wrapper = obj
+        if len(reg.arginfo(obj).args) == 3:
+            @wraps(obj)
+            def wrapper(app, identity, model, permission):
+                return obj(identity, model, permission)
         reg_registry.register_function(
-            generic.permits, obj,
+            generic.permits, wrapper,
             identity=self.identity,
             obj=self.model,
             permission=self.permission)

--- a/morepath/generic.py
+++ b/morepath/generic.py
@@ -123,7 +123,7 @@ def verify_identity(identity):
 @reg.dispatch('identity', 'obj',
               reg.match_class('permission',
                               lambda permission: permission))
-def permits(identity, obj, permission):
+def permits(app, identity, obj, permission):
     """Returns ``True`` if identity has permission for model object.
 
     identity can be the special :data:`morepath.NO_IDENTITY`

--- a/morepath/tests/test_security.py
+++ b/morepath/tests/test_security.py
@@ -373,3 +373,52 @@ def test_prevent_poisoned_host_headers():
     for host in poisoned_hosts:
         response = c.get('/', headers={'Host': host}, expect_errors=True)
         assert response.status_code == 400
+
+
+def test_settings_in_permission_rule():
+
+    class App(morepath.App):
+        pass
+
+    @App.path(path='{id}')
+    class Model(object):
+        def __init__(self, id):
+            self.id = id
+
+    class Permission(object):
+        pass
+
+    @App.verify_identity()
+    def verify_identity(identity):
+        return True
+
+    @App.setting_section(section="permissions")
+    def get_roles_setting():
+        return {
+            'read': {'foo'},
+        }
+
+    @App.permission_rule(model=Model, permission=Permission)
+    def get_permission(app, identity, model, permission):
+        return model.id in app.settings.permissions.read
+
+    @App.view(model=Model, permission=Permission)
+    def default(self, request):
+        return "Model: %s" % self.id
+
+    @App.identity_policy()
+    class IdentityPolicy(object):
+        def identify(self, request):
+            return Identity('testidentity')
+
+        def remember(self, response, request, identity):
+            pass
+
+        def forget(self, response, request):
+            pass
+
+    c = Client(App())
+
+    response = c.get('/foo')
+    assert response.body == b'Model: foo'
+    response = c.get('/bar', status=403)

--- a/morepath/view.py
+++ b/morepath/view.py
@@ -64,8 +64,9 @@ class View(object):
         if self.internal:
             raise HTTPNotFound()
         if (self.permission is not None and
-            not generic.permits(request.identity, obj, self.permission,
-                                lookup=request.lookup)):
+            not generic.permits(
+                request.app, request.identity, obj, self.permission,
+                lookup=request.lookup)):
             raise HTTPForbidden()
         content = self.func(obj, request)
         if isinstance(content, BaseResponse):


### PR DESCRIPTION
This PR is a possible solution to #472:

``morepath.App.permission_rule`` can be used to decorate a function with signature ``f(app, identity, model, permission)`` or ``f(identity, model, permission)``, the latter for backward compatibility.