### PR TITLE
feat: add a setting_handler directive to register call-back functions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ CHANGES
 0.18 (unreleased)
 =================
 
+* **New**: Added a ``setting_handler`` directive to register call-back
+  functions in the settings.
+
 * **Removed**: ``morepath.body_model_predicate`` is removed from the
   Morepath API together with the ``morepath.App.load_json`` directive
   and the ``morepath.request.body_obj`` property.

--- a/doc/extension_api.rst
+++ b/doc/extension_api.rst
@@ -36,6 +36,10 @@ helpful when you want to implement your own actions. See
 
   :meth:`morepath.App.setting`
 
+.. py:class:: SettingHandlerAction
+
+  :meth:`morepath.App.setting_handler`
+
 .. py:class:: SettingSectionAction
 
   :meth:`morepath.App.setting_section`

--- a/doc/settings.rst
+++ b/doc/settings.rst
@@ -22,6 +22,7 @@ app that extends another app to override settings. This lets an app
 that defines a framework can also define default settings that can be
 overridden by the extending application if needed.
 
+
 Defining a setting
 ------------------
 
@@ -43,6 +44,19 @@ You can also use this directive to override a setting in another app::
 Settings are grouped logically: a setting is in a *section* and has a
 *name*. This way you can organize all settings that deal with logging
 under the ``logging`` section.
+
+
+Defining a callback function as a setting
+-----------------------------------------
+
+For handlers and call-back functions it can be useful to register the function
+itself as a setting.
+In this case you can use the :meth:`@App.setting_handler` directive instead::
+
+  @App.setting_handler(section="jwtauth", name="refresh_nonce_handler")
+  def refresh_nonce_handler(userid):
+      return User.get(email=userid).nonce
+
 
 Accessing a setting
 -------------------
@@ -74,6 +88,7 @@ You can do this using the :meth:`App.setting_section` directive::
 You can mix ``setting`` and ``setting_section`` freely, but you cannot
 define a setting multiple times in the same app, as this will result
 in a configuration conflict.
+
 
 Loading settings from a config file
 -----------------------------------

--- a/morepath/app.py
+++ b/morepath/app.py
@@ -85,6 +85,7 @@ class App(dectate.App):
     """
 
     setting = directive(action.SettingAction)
+    setting_handler = directive(action.SettingHandlerAction)
     setting_section = directive(action.SettingSectionAction)
     predicate_fallback = directive(action.PredicateFallbackAction)
     predicate = directive(action.PredicateAction)

--- a/morepath/directive.py
+++ b/morepath/directive.py
@@ -87,6 +87,13 @@ class SettingValue(object):
         return self.value
 
 
+class SettingHandlerAction(SettingAction):
+    def perform(self, obj, setting_registry):
+        setting_registry.register_setting(
+            self.section, self.name, SettingValue(obj)
+        )
+
+
 class SettingSectionAction(dectate.Composite):
     query_classes = [SettingAction]
 

--- a/morepath/tests/test_setting_directive.py
+++ b/morepath/tests/test_setting_directive.py
@@ -17,6 +17,22 @@ def test_settings_property():
     app = App()
 
     assert app.settings is app.config.setting_registry
+    assert app.settings.foo.bar == 'bar'
+
+
+def test_setting_handler():
+    class App(morepath.App):
+        pass
+
+    @App.setting_handler('foo', 'input_handler')
+    def input_handler(input):
+        return '__' + input + '__'
+
+    dectate.commit(App)
+    app = App()
+
+    handler = app.settings.foo.input_handler
+    assert handler('test') == '__test__'
 
 
 def test_app_extends_settings():


### PR DESCRIPTION
I think it is common to register a handler in the settings to use it from a plugin or service.
In Django they use therefor a dotted path in the settings which also works for Morepath.

But I think this is a more elegant way. You just decorate your handler with `setting_handler`:
```python
@App.setting_handler(section="jwtauth", name="refresh_nonce_handler")
def refresh_nonce_handler(userid):
    return User.get(email=userid).nonce
```