### PR TITLE
Travis CI 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,22 @@
 sudo: false
 language: python
 
-python: 3.5
-env:
-    - TOXENV=py27
-    - TOXENV=py33
-    - TOXENV=py34
-    - TOXENV=py35
-    - TOXENV=pypy
-    - TOXENV=docs
-    - TOXENV=pep8
-    - TOXENV=coverage
+python:
+    - "2.7"
+    - "pypy"
+    - "3.4"
+    - "3.5"
+    - "3.6"
+matrix:
+    include:
+    - python: "3.5"
+      env: TOXENV="-e docs"
+    - python: "3.5"
+      env: TOXENV="-e pep8"
+    - python: "3.5"
+      env: TOXENV="-e coverage"
 install:
     - pip install --upgrade pip setuptools
-    - pip install tox
+    - pip install tox-travis
 script:
-    - tox -c .travis_tox.ini -e $TOXENV
+    - tox -c .travis_tox.ini $TOXENV

--- a/.travis_tox.ini
+++ b/.travis_tox.ini
@@ -1,7 +1,7 @@
 # This is the configuration file for tox used by Travis CI
 
 [tox]
-envlist = py27,pypy,py33,py34,py35,pep8,coverage,docs
+envlist = py27,pypy,py34,py35,py36,pep8,coverage,docs
 
 [testenv]
 deps = -r{toxinidir}/requirements/corelibs.txt

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ CHANGES
 0.19 (unreleased)
 =================
 
-- Nothing changed yet.
+* Added support for Python 3.6 and dropped support for Python 3.3
 
 
 0.18.1 (2017-06-30)

--- a/morepath/tests/test_mount_directive.py
+++ b/morepath/tests/test_mount_directive.py
@@ -1098,9 +1098,9 @@ def test_mount_ancestors():
 
     @app.view(model=AppRoot)
     def app_root_default(self, request):
-        l = list(request.app.ancestors())
-        assert len(l) == 1
-        assert l[0] is request.app
+        ancestors = list(request.app.ancestors())
+        assert len(ancestors) == 1
+        assert ancestors[0] is request.app
         assert request.app.root is request.app
 
     @mounted.path(path='')
@@ -1109,10 +1109,10 @@ def test_mount_ancestors():
 
     @mounted.view(model=MountedRoot)
     def mounted_root_default(self, request):
-        l = list(request.app.ancestors())
-        assert len(l) == 2
-        assert l[0] is request.app
-        assert l[1] is request.app.parent
+        ancestors = list(request.app.ancestors())
+        assert len(ancestors) == 2
+        assert ancestors[0] is request.app
+        assert ancestors[1] is request.app.parent
         assert request.app.root is request.app.parent
 
     @app.mount(path='{id}', app=mounted)

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,9 @@ setup(
         'Topic :: Software Development :: Libraries :: Application Frameworks',
         'Topic :: Internet :: WWW/HTTP :: WSGI',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Development Status :: 5 - Production/Stable'
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.4.1
-envlist = py27,pypy,py33,py34,py35,pep8,coverage,docs
+envlist = py27,pypy,py34,py35,py36,pep8,coverage,docs
 skipsdist = True
 skip_missing_interpreters = True
 


### PR DESCRIPTION
Use travis-tox for compatibility with Pypy
Remove 3.3 as it's unsupported by pytest
Add 3.6 to tox
Fix PEP8 violation in tests