### PR TITLE
Fix link to namespace packages documentation

### DIFF
--- a/doc/organizing_your_project.rst
+++ b/doc/organizing_your_project.rst
@@ -168,7 +168,7 @@ Inside is the normal package called ``core``.
 
 See also the `namespace packages documentation`_.
 
-.. _`namespace packages documentation`: http://pythonhosted.org/setuptools/setuptools.html#namespace-packages
+.. _`namespace packages documentation`: https://setuptools.readthedocs.io/en/latest/setuptools.html#namespace-packages
 
 App Module
 -----------


### PR DESCRIPTION
I encountered a broken link while browsing the tutorial. I think it should point to http://setuptools.readthedocs.io.