### PR TITLE
Fix PEP 8 in settings.py

### DIFF
--- a/morepath/tests/fixtures/config/settings.py
+++ b/morepath/tests/fixtures/config/settings.py
@@ -38,8 +38,8 @@ settings = {
 
 
 def create_json_config():
-        stream = open('settings.json', 'w')
-        json.dump(settings, stream, sort_keys=True, indent=4,
-                  separators=(',', ': '))
-        print(json.dumps(settings, sort_keys=True, indent=4,
-                         separators=(',', ': ')))
+    stream = open('settings.json', 'w')
+    json.dump(settings, stream, sort_keys=True, indent=4,
+              separators=(',', ': '))
+    print(json.dumps(settings, sort_keys=True, indent=4,
+                     separators=(',', ': ')))


### PR DESCRIPTION
... and thus make Travis go green for all build jobs.

modified:   morepath/tests/fixtures/config/settings.py