### PR TITLE
Restrict paths for flake8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ basepython = python3.7
 extras = pep8
 deps = {[src]deps}
 
-commands = flake8
+commands = flake8 morepath/ setup.py
            black --check .
 
 [testenv:coverage]


### PR DESCRIPTION
Make sure flake8 only lints the source code, tests and setup.py.

Before this change, also the development checkouts within the `src`
directory were linted.

modified:   tox.ini