### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/doc/json.rst
+++ b/doc/json.rst
@@ -51,7 +51,7 @@ Now we can write a JSON view that just returns an ``Item`` instance::
   def item_default(self, request):
       return self
 
-The ``self`` we return in this view is an istance of ``Item``. This is
+The ``self`` we return in this view is an instance of ``Item``. This is
 now automatically converted to a JSON object.
 
 load function for views

--- a/doc/web.rst
+++ b/doc/web.rst
@@ -448,7 +448,7 @@ client.
 WebOb makes management of cookies more convenient: the
 :attr:`webob.request.BaseRequest.cookies` attribute on the request
 object contains the list of cookies sent by the client, and the
-response object has an API incuding
+response object has an API including
 :meth:`webob.response.Response.set_cookie` and
 :meth:`webob.response.Response.delete_cookie` to allow you to manage
 cookies.

--- a/morepath/app.py
+++ b/morepath/app.py
@@ -365,7 +365,7 @@ class App(dectate.App):
 
         :param model: model class or :class:`morepath.App` subclass.
         :param variables: dictionary with variables to reconstruct
-        the path and URL paramaters from path pattern.
+        the path and URL parameters from path pattern.
         :return: a :class:`morepath.path.PathInfo` with path within this app,
           or ``None`` if the path couldn't be determined.
         """

--- a/morepath/autosetup.py
+++ b/morepath/autosetup.py
@@ -103,7 +103,7 @@ def autoscan(ignore=None):
     See also :func:`scan`.
 
     :param ignore: ignore to ignore some modules
-      during scanning. Optional. If ommitted, ignore ``.test`` and
+      during scanning. Optional. If omitted, ignore ``.test`` and
       ``.tests`` packages by default. See :func:`importscan.scan` for
       more details.
 

--- a/morepath/tests/test_excview.py
+++ b/morepath/tests/test_excview.py
@@ -117,7 +117,7 @@ def test_excview_named_view():
     def view(self, request):
         raise MyException()
 
-    # the view name should have no infleunce on myexception lookup
+    # the view name should have no influence on myexception lookup
     @app.view(model=MyException)
     def myexception_default(self, request):
         return "My exception"

--- a/morepath/tests/test_request.py
+++ b/morepath/tests/test_request.py
@@ -6,7 +6,7 @@ def test_request_reset():
     # In order to  verify the behaviour of Request.reset  we issue the
     # same request three times:
     #
-    # 1. The server responds succesfully (generate_error = False)
+    # 1. The server responds successfully (generate_error = False)
     #
     # 2. The server responds with an error (generate_error = True) and
     # returns the request as it was when the exception was thrown

--- a/morepath/tests/test_run.py
+++ b/morepath/tests/test_run.py
@@ -24,7 +24,7 @@ script-name: error: argument -p/--port: invalid integer in 0..65535 value: '-3'
 
 
 def test_run_socketerror(mockserver, capsys):
-    """Fail gracefuly on a socket error.
+    """Fail gracefully on a socket error.
 
     In this case the error is triggered by listening on example.com.
 

--- a/morepath/tests/test_security.py
+++ b/morepath/tests/test_security.py
@@ -415,7 +415,7 @@ def test_false_verify_identity():
 
 def test_dispatch_verify_identity():
     # This app uses two Identity classes, morepath.Identity and
-    # Anonymous, which are verfied in two different ways (see the two
+    # Anonymous, which are verified in two different ways (see the two
     # functions a little further down that are decorated by
     # @App.verify_identity).
     class App(morepath.App):


### PR DESCRIPTION
There are small typos in:
- doc/json.rst
- doc/web.rst
- morepath/app.py
- morepath/autosetup.py
- morepath/tests/test_excview.py
- morepath/tests/test_request.py
- morepath/tests/test_run.py
- morepath/tests/test_security.py

Fixes:
- Should read `verified` rather than `verfied`.
- Should read `successfully` rather than `succesfully`.
- Should read `parameters` rather than `paramaters`.
- Should read `omitted` rather than `ommitted`.
- Should read `instance` rather than `istance`.
- Should read `influence` rather than `infleunce`.
- Should read `including` rather than `incuding`.
- Should read `gracefully` rather than `gracefuly`.

Closes #551