### PR TITLE
Add type hints

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-ignore = E203, E231, W503
-show-source = True
-max-line-length = 90

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,13 +38,17 @@ jobs:
             python-version: "3.11"
           - tox-env: "lint"
             python-version: "3.11"
+          - tox-env: "mypy"
+            python-version: "3.11"
+          - tox-env: "pyright"
+            python-version: "3.11"
           - tox-env: "docs"
             python-version: "3.11"
     
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: "actions/checkout@v5"
+      - uses: "actions/checkout@v6"
       - uses: "actions/setup-python@v6"
         with:
           python-version: "${{ matrix.python-version }}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.11.0
+    rev: 26.5.1
     hooks:
       - id: black
         args: [--line-length=80]
@@ -8,8 +8,9 @@ repos:
     rev: "7.3.0"
     hooks:
       - id: flake8
+        additional_dependencies: [flake8-pyproject]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.1
+    rev: v3.21.2
     hooks:
     - id: pyupgrade
       args: [--py310-plus]

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,14 @@ CHANGES
 0.21 (unreleased)
 =================
 
+* Add type hints
+
+* Fixes a minor bug in ``Request.view``
+  
+  If the targeted view was mounted on a different application instance
+  and that view threw an exception, then the bound application object
+  was not properly restored back to the original instance.
+
 * Fix readthedocs integration.
 
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include *.txt *.rst *.py *.toml *.yaml .flake8
-recursive-include morepath *.py *.format
+recursive-include morepath *.py *.format py.typed
 recursive-include doc *.rst Makefile *.py *.bat *.json *.yml
 recursive-include fixture_packages *.py
 recursive-include requirements *.txt

--- a/morepath/__init__.py
+++ b/morepath/__init__.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 """This is the main public API of Morepath.
 
 Additional public APIs can be imported from the :mod:`morepath.error`
@@ -32,3 +31,28 @@ from .reify import reify
 from .request import Request, Response
 from .run import run
 from .view import redirect, render_html, render_json
+
+__all__ = (
+    "EXCVIEW",
+    "HOST_HEADER_PROTECTION",
+    "LAST_VIEW_PREDICATE",
+    "NO_IDENTITY",
+    "App",
+    "Converter",
+    "Identity",
+    "IdentityPolicy",
+    "Response",
+    "Request",
+    "autoscan",
+    "commit",
+    "dispatch_method",
+    "model_predicate",
+    "name_predicate",
+    "redirect",
+    "reify",
+    "render_html",
+    "render_json",
+    "request_method_predicate",
+    "run",
+    "scan",
+)

--- a/morepath/app.py
+++ b/morepath/app.py
@@ -15,6 +15,12 @@ To actually serve requests it uses :func:`morepath.publish.publish`.
 Entirely documented in :class:`morepath.App` in the public API.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from typing import NoReturn as Never
+from typing import TypeVar, overload
+
 from webob.exc import HTTPNotFound
 
 import dectate
@@ -27,20 +33,48 @@ from .path import PathInfo
 from .reify import reify
 from .request import Request
 
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Iterator
+    from typing_extensions import Self
 
-def cached_key_lookup(key_lookup):
+    from webob.response import Response as BaseResponse
+
+    from reg.cache import DictCachingKeyLookup
+    from reg.predicate import Predicate
+    from reg.types import GetKeyLookup, KeyLookup
+
+    from .authentication import Identity, NoIdentity
+    from .settings import SettingRegistry
+    from .tween import TweenRegistry
+    from .types import AnyRequest, StartResponse, SupportsItems, WSGIEnvironment
+
+_T = TypeVar("_T")
+_AppT = TypeVar("_AppT", bound="App")
+
+
+def cached_key_lookup(key_lookup: KeyLookup) -> DictCachingKeyLookup:
     return reg.DictCachingKeyLookup(key_lookup)
 
 
-def commit_if_needed(app):
+def commit_if_needed(app: App) -> None:
     if not app.is_committed():
         app.commit()
 
 
-def dispatch_method(*predicates, **kw):
-    kw.setdefault("get_key_lookup", cached_key_lookup)
-    kw.setdefault("first_invocation_hook", commit_if_needed)
-    return reg.dispatch_method(*predicates, **kw)
+def dispatch_method(
+    *predicates: str | Predicate,
+    get_key_lookup: GetKeyLookup = cached_key_lookup,
+    first_invocation_hook: Callable[[Any], object] = commit_if_needed,
+    # NOTE: We keep allowing arbitrary keyword arguments at runtime
+    #       for now, but type checkers should emit an error for these.
+    **kw: Never,
+) -> reg.dispatch_method[Any, Any, Any]:
+    return reg.dispatch_method(
+        *predicates,
+        get_key_lookup=get_key_lookup,
+        first_invocation_hook=first_invocation_hook,
+        **kw,
+    )
 
 
 dispatch_method.__doc__ = reg.dispatch_method.__doc__
@@ -71,10 +105,10 @@ class App(dectate.App):
     new directives.
     """
 
-    parent = None
+    parent: App | None = None
     """The parent in which this app was mounted."""
 
-    request_class = Request
+    request_class: type[Request[Self]] = Request
     """The class of the Request to create. Must be a subclass of
     :class:`morepath.Request`.
 
@@ -109,10 +143,10 @@ class App(dectate.App):
     dump_json = directive(action.DumpJsonAction)
     link_prefix = directive(action.LinkPrefixAction)
 
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
-    def request(self, environ):
+    def request(self, environ: WSGIEnvironment) -> Request[Self]:
         """Create a :class:`Request` given WSGI environment for this app.
 
         :param environ: WSGI environment
@@ -120,7 +154,9 @@ class App(dectate.App):
         """
         return self.request_class(environ, self)
 
-    def __call__(self, environ, start_response):
+    def __call__(
+        self, environ: WSGIEnvironment, start_response: StartResponse
+    ) -> Iterable[bytes]:
         """This app as a WSGI application.
 
         See the WSGI_ spec for more information.
@@ -139,7 +175,7 @@ class App(dectate.App):
         return response(environ, start_response)
 
     @reify
-    def publish(self):
+    def publish(self) -> Callable[[AnyRequest], BaseResponse]:
         """Publish functionality wrapped in tweens.
 
         You can use middleware (:doc:`tweens`) that can hooks in
@@ -161,25 +197,34 @@ class App(dectate.App):
         # lookup may not be touched yet at this point
         if not self.is_committed():
             self.commit()
-        return self.config.tween_registry.wrap(self)
 
-    def ancestors(self):
+        registry: TweenRegistry = self.config.tween_registry
+        return registry.wrap(self)
+
+    def ancestors(self) -> Iterator[App]:
         """Return iterable of all ancestors of this app.
 
         Includes this app itself as the first ancestor, all the way
         up to the root app in the mount chain.
         """
-        app = self
+        app: App | None = self
         while app is not None:
             yield app
             app = app.parent
 
     @reify
-    def root(self):
+    def root(self) -> App:
         """The root application."""
         return list(self.ancestors())[-1]
 
-    def child(self, app, **variables):
+    @overload
+    def child(self, app: type[_AppT], **variables: Any) -> _AppT | None: ...
+    @overload
+    def child(self, app: _AppT) -> _AppT | None: ...
+    @overload
+    def child(self, app: str, **variables: Any) -> App | None: ...
+
+    def child(self, app: type[App] | App | str, **variables: Any) -> App | None:
         """Get app mounted in this app.
 
         Either give it an instance of the app class as the first
@@ -209,7 +254,16 @@ class App(dectate.App):
         result.parent = self
         return result
 
-    def sibling(self, app, **variables):
+    @overload
+    def sibling(self, app: _AppT) -> _AppT | None: ...
+    @overload
+    def sibling(self, app: type[_AppT], **variables: Any) -> _AppT | None: ...
+    @overload
+    def sibling(self, app: str, **variables: Any) -> App | None: ...
+
+    def sibling(
+        self, app: type[App] | App | str, **variables: Any
+    ) -> App | None:
         """Get app mounted next to this app.
 
         Either give it an instance of the app class as the first
@@ -227,12 +281,14 @@ class App(dectate.App):
         return parent.child(app, **variables)
 
     @property
-    def settings(self):
+    def settings(self) -> SettingRegistry:
         """Returns the settings bound to this app."""
-        return self.config.setting_registry
+        return self.config.setting_registry  # type: ignore[no-any-return]
 
     @classmethod
-    def mounted_app_classes(cls, callback=None):
+    def mounted_app_classes(
+        cls, callback: Callable[..., object] | None = None
+    ) -> set[type[App]]:
         """Returns a set of this app class and any mounted under it.
 
         This assumes all app classes involved have already been
@@ -251,7 +307,7 @@ class App(dectate.App):
         :return: the set of app classes.
 
         """
-        discovery = set()
+        discovery: set[type[App]] = set()
         found = {cls}
         while found:
             discovery.update(found)
@@ -263,7 +319,7 @@ class App(dectate.App):
         return discovery
 
     @classmethod
-    def commit(cls):
+    def commit(cls) -> set[type[App]]:
         """Commit the app, and recursively, the apps mounted under it.
 
         Mounted apps are discovered in breadth-first order.
@@ -273,7 +329,9 @@ class App(dectate.App):
         return cls.mounted_app_classes(dectate.commit)
 
     @classmethod
-    def init_settings(cls, settings):
+    def init_settings(
+        cls, settings: SupportsItems[str, SupportsItems[str, Any]]
+    ) -> None:
         """Pre-fill the settings before the app is started.
 
         Add settings to App, which can act as normal, can be overridden, etc.
@@ -282,14 +340,16 @@ class App(dectate.App):
           dictionaries of settings.
         """
 
-        def set_setting_section(section, section_settings):
+        def set_setting_section(
+            section: str, section_settings: SupportsItems[str, Any]
+        ) -> None:
             cls.setting_section(section)(lambda: section_settings)
 
         for section, section_settings in settings.items():
             set_setting_section(section, section_settings)
 
     @dispatch_method()
-    def get_view(self, obj, request):
+    def get_view(self, obj: Any, request: Request) -> BaseResponse:
         """Get the view that represents the obj in the context of a request.
 
         This view is a representation of the obj that can be rendered to a
@@ -311,7 +371,7 @@ class App(dectate.App):
         return HTTPNotFound()
 
     @dispatch_method("identity")
-    def _verify_identity(self, identity):
+    def _verify_identity(self, identity: Identity) -> bool:
         """Returns True if the claimed identity can be verified.
 
         Look in the database to verify the identity, or in case of auth
@@ -324,7 +384,9 @@ class App(dectate.App):
         return False
 
     @dispatch_method("identity", "obj", reg.match_class("permission"))
-    def _permits(self, identity, obj, permission):
+    def _permits(
+        self, identity: Identity | NoIdentity, obj: Any, permission: Any
+    ) -> bool:
         """Returns ``True`` if identity has permission for model object.
 
         identity can be the special :data:`morepath.NO_IDENTITY`
@@ -339,7 +401,7 @@ class App(dectate.App):
         return False
 
     @dispatch_method("obj")
-    def _dump_json(self, obj, request):
+    def _dump_json(self, obj: Any, request: AnyRequest) -> Any:
         """Dump an object as JSON.
 
         ``obj`` is any Python object, try to interpret it as JSON.
@@ -350,7 +412,7 @@ class App(dectate.App):
         """
         return obj
 
-    def _link_prefix(self, request):
+    def _link_prefix(self, request: AnyRequest) -> str:
         """Returns a prefix that's added to every link generated by request.
 
         By default :attr:`webob.request.BaseRequest.application_url` is used.
@@ -358,10 +420,12 @@ class App(dectate.App):
         :param request: :class:`morepath.Request`
         :return: prefix string to add before links.
         """
-        return request.application_url
+        return request.application_url  # type: ignore[no-any-return]
 
     @dispatch_method(reg.match_class("model"))
-    def _class_path(self, model, variables):
+    def _class_path(
+        self, model: type[Any], variables: dict[str, Any]
+    ) -> PathInfo | None:
         """Get the path for a model class.
 
         :param model: model class or :class:`morepath.App` subclass.
@@ -373,7 +437,7 @@ class App(dectate.App):
         return None
 
     @dispatch_method("obj")
-    def _path_variables(self, obj):
+    def _path_variables(self, obj: Any) -> dict[str, Any] | None:
         """Get variables to use in path generation.
 
         :param obj: model object or :class:`morepath.App` instance.
@@ -383,7 +447,7 @@ class App(dectate.App):
         return self._default_path_variables(obj)
 
     @dispatch_method("obj")
-    def _default_path_variables(self, obj):
+    def _default_path_variables(self, obj: Any) -> dict[str, Any] | None:
         """Get default variables to use in path generation.
 
         Invoked if no specific ``path_variables`` is registered.
@@ -395,7 +459,7 @@ class App(dectate.App):
         return None
 
     @dispatch_method("obj")
-    def _deferred_link_app(self, obj):
+    def _deferred_link_app(self, obj: Any) -> App | None:
         """Get application used for link generation.
 
         :param obj: model object to link to.
@@ -406,7 +470,9 @@ class App(dectate.App):
         return None
 
     @dispatch_method(reg.match_class("model"))
-    def _deferred_class_link_app(self, model, variables):
+    def _deferred_class_link_app(
+        self, model: type[Any], variables: dict[str, Any] | None
+    ) -> App | None:
         """Get application used for link generation for a model class.
 
         :param model: model class
@@ -418,10 +484,10 @@ class App(dectate.App):
         return None
 
     @classmethod
-    def clean(cls):
+    def clean(cls) -> None:
         reg.clean_dispatch_methods(cls)
 
-    def _identify(self, request):
+    def _identify(self, request: AnyRequest) -> Identity | NoIdentity | None:
         """Determine identity for request.
 
         :param request: a :class:`morepath.Request` instance.
@@ -431,7 +497,9 @@ class App(dectate.App):
         """
         return None
 
-    def remember_identity(self, response, request, identity):
+    def remember_identity(
+        self, response: BaseResponse, request: AnyRequest, identity: Identity
+    ) -> None:
         """Modify response so that identity is remembered by client.
 
         :param response: :class:`morepath.Response` to remember identity on.
@@ -440,7 +508,9 @@ class App(dectate.App):
         """
         pass
 
-    def forget_identity(self, response, request):
+    def forget_identity(
+        self, response: BaseResponse, request: AnyRequest
+    ) -> None:
         """Modify response so that identity is forgotten by client.
 
         :param response: :class:`morepath.Response` to forget identity on.
@@ -448,7 +518,7 @@ class App(dectate.App):
         """
         pass
 
-    def _get_path(self, obj):
+    def _get_path(self, obj: Any) -> PathInfo | None:
         """Path for a model obj.
 
         Only includes path within the current app, does not take
@@ -457,9 +527,17 @@ class App(dectate.App):
         :param obj: model object
         :return: a :class:`morepath.path.PathInfo` with path within this app.
         """
-        return self._class_path(obj.__class__, self._path_variables(obj))
+        return self._class_path(
+            obj.__class__,
+            # NOTE: Path.__call__ will emit a LinkError if we got `None` back
+            #       for _path_variables, so we technically don't need to do to
+            #       anything here. It still might be worth to duplicate the
+            #       check and error generation to here, so it's a little bit
+            #       higher in the call stack.
+            self._path_variables(obj),  # type: ignore[arg-type]
+        )
 
-    def _get_mounted_path(self, obj):
+    def _get_mounted_path(self, obj: Any) -> PathInfo | None:
         """Path for model obj including mounted path.
 
         Includes path to this app itself, so takes mounting into account.
@@ -470,7 +548,7 @@ class App(dectate.App):
         """
         paths = []
         parameters = {}
-        app = self
+        app: App | None = self
         while app is not None:
             info = app._get_path(obj)
             if info is None:
@@ -482,7 +560,9 @@ class App(dectate.App):
         paths.reverse()
         return PathInfo("/".join(paths).strip("/"), parameters)
 
-    def _get_mounted_class_path(self, model, variables):
+    def _get_mounted_class_path(
+        self, model: type[Any], variables: dict[str, Any]
+    ) -> PathInfo | None:
         """Path for model class and variables including mounted path.
 
         Includes path to this app itself, so takes mounting into account.
@@ -498,6 +578,9 @@ class App(dectate.App):
         if self.parent is None:
             return info
         mount_info = self.parent._get_mounted_path(self)
+        # FIXME: Can mount_info be None if we got here? If so
+        #        what is the correct result?
+        assert mount_info is not None
         path = mount_info.path
         if info.path:
             path += "/" + info.path
@@ -505,7 +588,9 @@ class App(dectate.App):
         parameters.update(mount_info.parameters)
         return PathInfo(path, parameters)
 
-    def _get_deferred_mounted_path(self, obj):
+    def _get_deferred_mounted_path(
+        self, obj: Any
+    ) -> tuple[PathInfo | None, App | None]:
         """Path for obj taking into account deferring apps.
 
         Like :meth:`morepath.App._get_mounted_path` but takes
@@ -514,12 +599,14 @@ class App(dectate.App):
         account.
         """
 
-        def find(app, obj):
+        def find(app: App, obj: Any) -> PathInfo | None:
             return app._get_mounted_path(obj)
 
         return self._follow_defers(find, obj)
 
-    def _get_deferred_mounted_class_path(self, model, variables):
+    def _get_deferred_mounted_class_path(
+        self, model: type[Any], variables: dict[str, Any]
+    ) -> PathInfo | None:
         """Path for model and variables taking into account deferring apps.
 
         Like :meth:`morepath.App._get_mounted_class_path` but takes
@@ -527,13 +614,17 @@ class App(dectate.App):
         account.
         """
 
-        def find(app, model, variables):
+        def find(
+            app: App, model: type[Any], variables: dict[str, Any]
+        ) -> PathInfo | None:
             return app._get_mounted_class_path(model, variables)
 
         info, app = self._follow_class_defers(find, model, variables)
         return info
 
-    def _follow_defers(self, find, obj):
+    def _follow_defers(
+        self, find: Callable[[App, Any], _T | None], obj: Any
+    ) -> tuple[_T | None, App | None]:
         """Resolve to deferring app and find something.
 
         For ``obj``, look up deferring app as defined by
@@ -549,7 +640,7 @@ class App(dectate.App):
           which it was found.
         """
         seen = set()
-        app = self
+        app: App | None = self
         while app is not None:
             if app in seen:
                 raise LinkError("Circular defer. Cannot link to: %r" % obj)
@@ -569,7 +660,12 @@ class App(dectate.App):
             app = next_app
         return None, app
 
-    def _follow_class_defers(self, find, model, variables):
+    def _follow_class_defers(
+        self,
+        find: Callable[[App, type[Any], dict[str, Any]], _T | None],
+        model: type[Any],
+        variables: dict[str, Any],
+    ) -> tuple[_T | None, App | None]:
         """Resolve to deferring app and find something.
 
         For ``model`` and ``variables``, look up deferring app as defined
@@ -586,7 +682,7 @@ class App(dectate.App):
           which it was found.
         """
         seen = set()
-        app = self
+        app: App | None = self
         while app is not None:
             if app in seen:
                 raise LinkError("Circular defer. Cannot link to: %r" % model)

--- a/morepath/authentication.py
+++ b/morepath/authentication.py
@@ -10,7 +10,14 @@ directive.
 See also :class:`morepath.directive.IdentityPolicyRegistry`
 """
 
+from __future__ import annotations
+
 import abc
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .request import Response
+    from .types import AnyRequest
 
 
 class NoIdentity:
@@ -22,7 +29,7 @@ class NoIdentity:
     userid = None
 
 
-NO_IDENTITY = NoIdentity()
+NO_IDENTITY: NoIdentity = NoIdentity()
 """The identity if the request is anonymous.
 
 The user has not yet logged in.
@@ -36,7 +43,7 @@ class Identity:
     and authorize them you need to implement Morepath permission directives.
     """
 
-    def __init__(self, userid, **kw):
+    def __init__(self, userid: Any, **kw: Any) -> None:
         """
         :param userid: The userid of this identity
         :param kw: Extra information to store in identity.
@@ -50,7 +57,7 @@ class Identity:
             setattr(self, key, value)
         self.verified = None  # starts out as never verified
 
-    def as_dict(self):
+    def as_dict(self) -> dict[str, Any]:
         """Export identity as dictionary.
 
         This includes the userid and the extra keyword parameters used
@@ -63,6 +70,14 @@ class Identity:
             result[name] = getattr(self, name)
         return result
 
+    if TYPE_CHECKING:
+        # NOTE: Since the identity may contain any number of attributes
+        #       we need to let type checkers know about that. If people
+        #       want better type checking on their identities, they will
+        #       need to subclass this one and declare the attributes.
+        def __getattr__(self, key: str) -> Any:
+            pass
+
 
 class IdentityPolicy(metaclass=abc.ABCMeta):
     """Identity policy API.
@@ -72,7 +87,7 @@ class IdentityPolicy(metaclass=abc.ABCMeta):
     """
 
     @abc.abstractmethod
-    def identify(self, request):
+    def identify(self, request: AnyRequest) -> Identity | NoIdentity | None:
         """Establish what identity this user claims to have from request.
 
         :param request: Request to extract identity information from.
@@ -83,7 +98,9 @@ class IdentityPolicy(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def remember(self, response, request, identity):
+    def remember(
+        self, response: Response, request: AnyRequest, identity: Identity
+    ) -> None:
         """Remember identity on response.
 
         Implements ``morepath.App.remember_identity``, which is called
@@ -104,7 +121,7 @@ class IdentityPolicy(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def forget(self, response, request):
+    def forget(self, response: Response, request: AnyRequest) -> None:
         """Forget identity on response.
 
         Implements ``morepath.App.forget_identity``, which is called from

--- a/morepath/autosetup.py
+++ b/morepath/autosetup.py
@@ -5,16 +5,30 @@ This module defines functionality to automatically configure Morepath.
 are part of the public API.
 """
 
+from __future__ import annotations
+
 import importlib
 import sys
 from importlib.metadata import distributions
+from typing import TYPE_CHECKING
 
 import importscan
 
 from .error import AutoImportError
 
+if TYPE_CHECKING:
+    from collections.abc import Callable, Collection, Generator, Iterable
+    from importlib.metadata import Distribution
+    from types import ModuleType
 
-def scan(package=None, ignore=None, handle_error=None):
+    from importscan.types import IgnoreModule
+
+
+def scan(
+    package: ModuleType | None = None,
+    ignore: Iterable[IgnoreModule] | IgnoreModule | None = None,
+    handle_error: Callable[[str, Exception], object] | None = None,
+) -> None:
     """Scan package for configuration actions (decorators).
 
     It scans by recursively importing the package and any modules
@@ -36,7 +50,9 @@ def scan(package=None, ignore=None, handle_error=None):
     importscan.scan(package, ignore, handle_error)
 
 
-def autoscan(ignore=None):
+def autoscan(
+    ignore: Collection[IgnoreModule] | IgnoreModule | None = None,
+) -> None:
     """Automatically load Morepath configuration from packages.
 
     Morepath configuration consists of decorator calls on :class:`App`
@@ -116,7 +132,7 @@ def autoscan(ignore=None):
         importscan.scan(package, ignore)
 
 
-def morepath_packages():
+def morepath_packages() -> Generator[ModuleType]:
     """Iterable of modules that depend on morepath. Each such module is
     imported before it is returned.
 
@@ -136,7 +152,7 @@ def morepath_packages():
         yield import_package(distribution)
 
 
-def import_package(distribution):
+def import_package(distribution: Distribution) -> ModuleType:
     """
     Takes a importlib.Distribution and loads the module contained
     in it, if it matches the rules layed out in :func:`morepath.autoscan`.
@@ -154,16 +170,21 @@ class DependencyMap:
     that depend on Morepath, directly or indirectly.
     """
 
-    def __init__(self):
-        self._d = {}
+    def __init__(self) -> None:
+        self._d: dict[str, set[str]] = {}
 
-    def load(self):
+    def load(self) -> None:
         """Fill the registry with dependency information."""
         for dist in distributions():
             for r in dist.requires or []:
                 self._d.setdefault(dist.name, set()).add(r)
 
-    def depends(self, project_name, on_project_name, visited=None):
+    def depends(
+        self,
+        project_name: str,
+        on_project_name: str,
+        visited: set[str] | None = None,
+    ) -> bool:
         """Check whether project transitively depends on another.
 
         A project depends on another project if it directly or
@@ -189,7 +210,7 @@ class DependencyMap:
                 return True
         return False
 
-    def relevant_dists(self, on_project_name):
+    def relevant_dists(self, on_project_name: str) -> Generator[Distribution]:
         """Iterable of distributions that depend on project.
 
         Dependency is transitive.
@@ -204,7 +225,7 @@ class DependencyMap:
             yield dist
 
 
-def get_module_name(distribution):
+def get_module_name(distribution: Distribution) -> str:
     """Determines the module name to import from the given distribution.
 
     If an entry point named ``scan`` is found in the group ``morepath``,
@@ -230,7 +251,7 @@ def get_module_name(distribution):
 # taken from pyramid.path
 
 
-def caller_module(level=2):
+def caller_module(level: int = 2) -> ModuleType:
     """Give module where calling function is defined.
 
     :level: levels deep to look up the stack frame
@@ -242,7 +263,7 @@ def caller_module(level=2):
     return module
 
 
-def caller_package(level=2):
+def caller_package(level: int = 2) -> ModuleType:
     """Give package where calling function is defined.
 
     :level: levels deep to look up the stack frame

--- a/morepath/converter.py
+++ b/morepath/converter.py
@@ -12,11 +12,24 @@ also needs to be provided to support link generation.
 See also :class:`morepath.directive.ConverterRegistry`
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, overload
+
 import reg
 from dectate import DirectiveError
 
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
 
-class Converter:
+    from reg.types import DispatchCall
+
+    from .types import AnyConverter
+
+_T = TypeVar("_T")
+
+
+class Converter(Generic[_T]):
     """Decode from strings to objects and back.
 
     Used internally by the :meth:`morepath.App.converter` directive.
@@ -31,7 +44,11 @@ class Converter:
     # see https://docs.python.org/3.1/reference/datamodel.html#object.__hash__
     __hash__ = object.__hash__
 
-    def __init__(self, decode, encode=None):
+    def __init__(
+        self,
+        decode: Callable[[str], _T | None],
+        encode: Callable[[_T], str] | None = None,
+    ) -> None:
         """Create new converter.
 
         :param decode: function that given string can decode them into objects.
@@ -42,7 +59,7 @@ class Converter:
         self.single_decode = decode
         self.single_encode = encode or fallback_encode
 
-    def decode(self, strings):
+    def decode(self, strings: list[str]) -> _T | None:
         """Decode list of strings into Python value.
 
         String must have only a single entry.
@@ -54,7 +71,7 @@ class Converter:
             raise ValueError
         return self.single_decode(strings[0])
 
-    def encode(self, value):
+    def encode(self, value: _T) -> list[str]:
         """Encode Python value into list of strings.
 
         :param value: Python value
@@ -62,12 +79,12 @@ class Converter:
         """
         return [self.single_encode(value)]
 
-    def is_missing(self, value):
+    def is_missing(self, value: object) -> bool:
         """True is a given value is the missing value."""
         # a single value is missing if the list is empty
         return value == []
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, Converter):
             return False
         return (
@@ -75,11 +92,11 @@ class Converter:
             and self.single_encode is other.single_encode
         )
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         return not self == other
 
 
-class ListConverter:
+class ListConverter(Generic[_T]):
     """How to decode from list of strings to list of objects and back.
 
     Used :class:`morepath.converter.ConverterRegistry` to handle
@@ -88,14 +105,14 @@ class ListConverter:
     Used for decoding/encoding URL parameters and path variables.
     """
 
-    def __init__(self, converter):
+    def __init__(self, converter: Converter[_T]) -> None:
         """Create new converter.
 
         :param converter: the converter to use for list entries
         """
         self.converter = converter
 
-    def decode(self, strings):
+    def decode(self, strings: list[str]) -> list[_T | None]:
         """Decode list of strings into list of Python values.
 
         :param strings: list of strings
@@ -104,7 +121,7 @@ class ListConverter:
         decode = self.converter.single_decode
         return [decode(s) for s in strings]
 
-    def encode(self, values):
+    def encode(self, values: list[_T]) -> list[str]:
         """Encode list of Python values into list of strings
 
         :param values: list of Python values.
@@ -113,28 +130,28 @@ class ListConverter:
         encode = self.converter.single_encode
         return [encode(v) for v in values]
 
-    def is_missing(self, value):
+    def is_missing(self, value: object) -> bool:
         """True is a given value is the missing value."""
         # a list value is never missing, even if the list is empty
         return False
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, ListConverter):
             return False
         return self.converter == other.converter
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         return not self == other
 
 
-IDENTITY_CONVERTER = Converter(lambda s: s, lambda s: s)
+IDENTITY_CONVERTER: Converter[str] = Converter(lambda s: s, lambda s: s)
 """Converter that has no effect.
 
 String becomes string.
 """
 
 
-def get_converter(type):
+def get_converter(type: type[_T]) -> Converter[_T]:
     """Get the converter for a given type.
 
     :param type: a class or type.
@@ -152,13 +169,17 @@ class ConverterRegistry:
     Is aware of inheritance.
     """
 
-    def __init__(self):
-        self.get_converter = reg.dispatch(
-            reg.match_class("type"), get_key_lookup=reg.DictCachingKeyLookup
-        )(get_converter)
-        self.register_converter(type(None), IDENTITY_CONVERTER)
+    def __init__(self) -> None:
+        self.get_converter: DispatchCall[[type[Any]], Converter[Any]] = (
+            reg.dispatch(
+                reg.match_class("type"), get_key_lookup=reg.DictCachingKeyLookup
+            )(get_converter)
+        )
+        self.register_converter(type(None), IDENTITY_CONVERTER)  # type: ignore[misc]
 
-    def register_converter(self, type, converter):
+    def register_converter(
+        self, type: type[_T], converter: Converter[_T]
+    ) -> None:
         """Register a converter for type.
 
         :param type: the Python type for which to register
@@ -167,7 +188,22 @@ class ConverterRegistry:
         """
         self.get_converter.register(type=type)(lambda type: converter)
 
-    def actual_converter(self, spec):
+    @overload
+    def actual_converter(  # pyright: ignore[reportOverlappingOverload]
+        self, spec: list[type[_T]]
+    ) -> ListConverter[_T]: ...
+    @overload
+    def actual_converter(
+        self, spec: type[_T] | Converter[_T]
+    ) -> Converter[_T]: ...
+
+    # this is for the empty list case, pretty icky but nothing we can do
+    @overload
+    def actual_converter(self, spec: list[Any]) -> Converter[str | None]: ...
+
+    def actual_converter(
+        self, spec: list[type[_T]] | type[_T] | Converter[_T]
+    ) -> Converter[_T] | ListConverter[_T]:
         """Return an actual converter for a given spec.
 
         :param spec: if a type, return the registered converter for
@@ -177,17 +213,21 @@ class ConverterRegistry:
         """
         if isinstance(spec, list):
             if len(spec) == 0:
-                spec = IDENTITY_CONVERTER
+                converter: Converter[Any] = IDENTITY_CONVERTER
             else:
-                spec = self.actual_converter(spec[0])
-            return ListConverter(spec)
+                converter = self.actual_converter(spec[0])
+            return ListConverter(converter)
         if isinstance(spec, type):
             return self.get_converter(spec)
         return spec
 
-    def argument_and_explicit_converters(self, arguments, converters):
+    def argument_and_explicit_converters(
+        self,
+        arguments: Mapping[str, Any],
+        converters: Mapping[str, Converter[Any] | list[Any] | type[Any]],
+    ) -> dict[str, AnyConverter]:
         """Use explict converters unless none supplied, then use default args."""
-        result = {
+        result: dict[str, Converter[Any] | ListConverter[Any]] = {
             name: self.get_converter(type(value))
             for name, value in arguments.items()
         }

--- a/morepath/core.py
+++ b/morepath/core.py
@@ -20,9 +20,12 @@ subclass of :class:`morepath.App`. We do not guarantee we won't break
 your code with future version of Morepath if you do that, though.
 """
 
+from __future__ import annotations
+
 import re
 from datetime import date, datetime
 from time import mktime, strptime
+from typing import TYPE_CHECKING
 
 from webob.exc import (
     HTTPBadRequest,
@@ -38,9 +41,15 @@ from reg import ClassIndex, KeyIndex
 from .app import App
 from .converter import IDENTITY_CONVERTER, Converter
 
+if TYPE_CHECKING:
+    from webob import Response as BaseResponse
+
+    from .request import Request
+    from .types import Tween
+
 
 @App.predicate(App.get_view, name="model", default=None, index=ClassIndex)
-def model_predicate(self, obj, request):
+def model_predicate(self: App, obj: object, request: Request) -> type[object]:
     """match model argument by class.
 
     Predicate for :meth:`morepath.App.view`.
@@ -49,7 +58,7 @@ def model_predicate(self, obj, request):
 
 
 @App.predicate_fallback(App.get_view, model_predicate)
-def model_not_found(self, obj, request):
+def model_not_found(self: App, obj: object, request: Request) -> HTTPNotFound:
     """if model not matched, HTTP 404.
 
     Fallback for :meth:`morepath.App.view`.
@@ -60,7 +69,7 @@ def model_not_found(self, obj, request):
 @App.predicate(
     App.get_view, name="name", default="", index=KeyIndex, after=model_predicate
 )
-def name_predicate(self, obj, request):
+def name_predicate(self: App, obj: object, request: Request) -> str | None:
     """match name argument with request.view_name.
 
     Predicate for :meth:`morepath.App.view`.
@@ -69,7 +78,7 @@ def name_predicate(self, obj, request):
 
 
 @App.predicate_fallback(App.get_view, name_predicate)
-def name_not_found(self, obj, request):
+def name_not_found(self: App, obj: object, request: Request) -> HTTPNotFound:
     """if name not matched, HTTP 404.
 
     Fallback for :meth:`morepath.App.view`.
@@ -84,7 +93,7 @@ def name_not_found(self, obj, request):
     index=KeyIndex,
     after=name_predicate,
 )
-def request_method_predicate(self, obj, request):
+def request_method_predicate(self: App, obj: object, request: Request) -> str:
     """match request method.
 
     Predicate for :meth:`morepath.App.view`.
@@ -93,7 +102,9 @@ def request_method_predicate(self, obj, request):
 
 
 @App.predicate_fallback(App.get_view, request_method_predicate)
-def method_not_allowed(self, obj, request):
+def method_not_allowed(
+    self: App, obj: object, request: Request
+) -> HTTPMethodNotAllowed:
     """if request predicate not matched, method not allowed.
 
     Fallback for :meth:`morepath.App.view`.
@@ -102,47 +113,47 @@ def method_not_allowed(self, obj, request):
 
 
 @App.converter(type=int)
-def int_converter():
+def int_converter() -> Converter[int]:
     """Converter for int."""
     return Converter(int)
 
 
 @App.converter(type=str)
-def unicode_converter():
+def unicode_converter() -> Converter[str]:
     """Converter for text."""
     return IDENTITY_CONVERTER
 
 
-def date_decode(s):
+def date_decode(s: str) -> date:
     return date.fromtimestamp(mktime(strptime(s, "%Y%m%d")))
 
 
-def date_encode(d):
+def date_encode(d: date) -> str:
     return d.strftime("%Y%m%d")
 
 
 @App.converter(type=date)
-def date_converter():
+def date_converter() -> Converter[date]:
     """Converter for date."""
     return Converter(date_decode, date_encode)
 
 
-def datetime_decode(s):
+def datetime_decode(s: str) -> datetime:
     return datetime.fromtimestamp(mktime(strptime(s, "%Y%m%dT%H%M%S")))
 
 
-def datetime_encode(d):
+def datetime_encode(d: datetime) -> str:
     return d.strftime("%Y%m%dT%H%M%S")
 
 
 @App.converter(type=datetime)
-def datetime_converter():
+def datetime_converter() -> Converter[datetime]:
     """Converter for datetime."""
     return Converter(datetime_decode, datetime_encode)
 
 
 @App.tween_factory()
-def excview_tween_factory(app, handler):
+def excview_tween_factory(app: App, handler: Tween) -> Tween:
     """Exception views.
 
     If an exception is raised by application code and a view is
@@ -152,7 +163,7 @@ def excview_tween_factory(app, handler):
     500 internal server error and an exception logged.
     """
 
-    def excview_tween(request):
+    def excview_tween(request: Request) -> BaseResponse:
         try:
             response = handler(request)
         except Exception as exc:
@@ -177,7 +188,9 @@ def excview_tween_factory(app, handler):
 
 
 @App.tween_factory(over=excview_tween_factory)
-def poisoned_host_header_protection_tween_factory(app, handler):
+def poisoned_host_header_protection_tween_factory(
+    app: App, handler: Tween
+) -> Tween:
     """Protect Morepath applications against the most basic host header
     poisoning attacts.
 
@@ -194,7 +207,7 @@ def poisoned_host_header_protection_tween_factory(app, handler):
         r"^([a-z0-9.\-_]+|\[[a-f0-9]*:[a-f0-9:]+\])(:\d+)?$"
     )
 
-    def poisoned_host_header_protection_tween(request):
+    def poisoned_host_header_protection_tween(request: Request) -> BaseResponse:
         if not valid_host_re.match(request.host.lower()):
             return HTTPBadRequest("Invalid HOST header")
 
@@ -204,7 +217,9 @@ def poisoned_host_header_protection_tween_factory(app, handler):
 
 
 @App.view(model=HTTPException)
-def standard_exception_view(self, request):
+def standard_exception_view(
+    self: HTTPException, request: Request
+) -> HTTPException:
     """We want the webob standard responses for any webob-based HTTP exception.
 
     Applies to subclasses of :class:`webob.HTTPException`.

--- a/morepath/directive.py
+++ b/morepath/directive.py
@@ -29,10 +29,13 @@ from :mod:`morepath.directive`.
 
 """
 
+from __future__ import annotations
+
 import os
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import dectate
-from reg import methodify
+from reg import KeyIndex, methodify
 
 from .authentication import Identity, NoIdentity
 from .converter import ConverterRegistry
@@ -45,15 +48,36 @@ from .traject import Path
 from .tween import TweenRegistry
 from .view import View, render_html, render_json, render_view
 
+if TYPE_CHECKING:
+    from collections.abc import Callable, Collection, Generator
 
-def isbaseclass(a, b):
+    from webob import Response as BaseResponse
+
+    from reg.types import DispatchCall, DispatchMethodCall
+
+    from .app import App
+    from .types import (
+        AnyApp,
+        AnyRequest,
+        GetStrPath,
+        MaybeTakesApp,
+        StrPath,
+        SupportsItems,
+        TweenFactory,
+    )
+
+_T = TypeVar("_T")
+_AppT = TypeVar("_AppT", bound="App")
+
+
+def isbaseclass(a: type[object], b: type[object]) -> bool:
     return issubclass(b, a)
 
 
 class SettingAction(dectate.Action):
     config = {"setting_registry": SettingRegistry}
 
-    def __init__(self, section, name):
+    def __init__(self, section: str, name: str) -> None:
         """Register application setting.
 
         An application setting is registered under the
@@ -71,25 +95,25 @@ class SettingAction(dectate.Action):
         self.section = section
         self.name = name
 
-    def identifier(self, setting_registry):
+    def identifier(self, setting_registry: SettingRegistry) -> tuple[str, str]:
         return self.section, self.name
 
-    def perform(self, obj, setting_registry):
+    def perform(self, obj: Any, setting_registry: SettingRegistry) -> None:
         setting_registry.register_setting(self.section, self.name, obj)
 
 
 class SettingValue:
-    def __init__(self, value):
+    def __init__(self, value: Any) -> None:
         self.value = value
 
-    def __call__(self):
+    def __call__(self) -> Any:
         return self.value
 
 
 class SettingSectionAction(dectate.Composite):
     query_classes = [SettingAction]
 
-    def __init__(self, section):
+    def __init__(self, section: str) -> None:
         """Register application setting in a section.
 
         An application settings are registered under the ``settings``
@@ -105,7 +129,9 @@ class SettingSectionAction(dectate.Composite):
         """
         self.section = section
 
-    def actions(self, obj):
+    def actions(
+        self, obj: Callable[[], SupportsItems[str, Any]]
+    ) -> Generator[tuple[SettingAction, SettingValue]]:
         section = obj()
         for name, value in section.items():
             yield (
@@ -127,7 +153,9 @@ class PredicateFallbackAction(dectate.Action):
         "func": dectate.convert_dotted_name,
     }
 
-    def __init__(self, dispatch, func):
+    def __init__(
+        self, dispatch: DispatchCall[..., Any], func: Callable[..., Any]
+    ) -> None:
         """For a given dispatch and function dispatched to, register fallback.
 
         The fallback is called with the same arguments as the dispatch
@@ -140,10 +168,14 @@ class PredicateFallbackAction(dectate.Action):
         self.dispatch = dispatch
         self.func = func
 
-    def identifier(self, predicate_registry):
+    def identifier(
+        self, predicate_registry: PredicateRegistry
+    ) -> tuple[DispatchCall[..., Any], Callable[..., Any]]:
         return self.dispatch, self.func
 
-    def perform(self, obj, predicate_registry):
+    def perform(
+        self, obj: Callable[..., Any], predicate_registry: PredicateRegistry
+    ) -> None:
         predicate_registry.register_predicate_fallback(
             self.dispatch, self.func, obj
         )
@@ -163,7 +195,15 @@ class PredicateAction(dectate.Action):
 
     filter_name = {"before": "_before", "after": "_after"}
 
-    def __init__(self, dispatch, name, default, index, before=None, after=None):
+    def __init__(
+        self,
+        dispatch: DispatchCall[..., Any],
+        name: str,
+        default: Any,
+        index: type[KeyIndex],
+        before: Callable[..., Any] | None = None,
+        after: Callable[..., Any] | None = None,
+    ) -> None:
         """Register a custom predicate for a dispatch method.
 
         The function to be registered should have the same arguments
@@ -196,10 +236,16 @@ class PredicateAction(dectate.Action):
         self._before = before
         self._after = after
 
-    def identifier(self, predicate_registry):
+    def identifier(self, predicate_registry: PredicateRegistry) -> tuple[
+        DispatchCall[..., Any],
+        Callable[..., Any] | None,
+        Callable[..., Any] | None,
+    ]:
         return self.dispatch, self._before, self._after
 
-    def perform(self, obj, predicate_registry):
+    def perform(
+        self, obj: Callable[..., Any], predicate_registry: PredicateRegistry
+    ) -> None:
         predicate_registry.register_predicate(
             obj,
             self.dispatch,
@@ -211,7 +257,7 @@ class PredicateAction(dectate.Action):
         )
 
     @staticmethod
-    def after(predicate_registry):
+    def after(predicate_registry: PredicateRegistry) -> None:
         predicate_registry.install_predicates()
 
 
@@ -220,7 +266,7 @@ class MethodAction(dectate.Action):
 
     depends = [SettingAction, PredicateAction, PredicateFallbackAction]
 
-    def filter_get_value(self, name):
+    def filter_get_value(self, name: str) -> Any | dectate.Sentinel:
         return self.key_dict.get(name, dectate.NOT_FOUND)
 
     app_class_arg = True
@@ -229,7 +275,9 @@ class MethodAction(dectate.Action):
     # the convert
     filter_convert = {"dispatch_method": dectate.convert_dotted_name}
 
-    def __init__(self, dispatch_method, **kw):
+    def __init__(
+        self, dispatch_method: DispatchMethodCall[..., Any, Any], **kw: Any
+    ) -> None:
         """Register function as implementation of dispatch method.
 
         This way you can create new hookable functions of your own, or
@@ -256,13 +304,17 @@ class MethodAction(dectate.Action):
         self.dispatch_method = dispatch_method
         self.key_dict = kw
 
-    def identifier(self, app_class):
+    def identifier(
+        self, app_class: type[dectate.App]
+    ) -> tuple[DispatchMethodCall[..., Any, Any], tuple[Any, ...]]:
         return (
             self.dispatch_method,
             self.dispatch_method.by_predicates(**self.key_dict).key,
         )
 
-    def perform(self, obj, app_class):
+    def perform(
+        self, obj: Callable[..., Any], app_class: type[dectate.App]
+    ) -> None:
         getattr(app_class, self.dispatch_method.__name__).register(
             obj, **self.key_dict
         )
@@ -276,7 +328,7 @@ class ConverterAction(dectate.Action):
     # use __builtin__.foo to match with builtin foo
     filter_convert = {"type": dectate.convert_dotted_name}
 
-    def __init__(self, type):
+    def __init__(self, type: type[Any]) -> None:
         """Register custom converter for type.
 
         :param type: the Python type for which to register the
@@ -291,10 +343,14 @@ class ConverterAction(dectate.Action):
         """
         self.type = type
 
-    def identifier(self, converter_registry):
+    def identifier(
+        self, converter_registry: ConverterRegistry
+    ) -> tuple[str, type[Any]]:
         return ("converter", self.type)
 
-    def perform(self, obj, converter_registry):
+    def perform(
+        self, obj: Callable[..., Any], converter_registry: ConverterRegistry
+    ) -> None:
         converter_registry.register_converter(self.type, obj())
 
 
@@ -312,29 +368,33 @@ class PathAction(dectate.Action):
 
     def __init__(
         self,
-        path,
-        model=None,
-        variables=None,
-        converters=None,
-        required=None,
-        get_converters=None,
-        absorb=False,
-    ):
-        self.model = model
+        path: str,
+        model: type[_T] | None = None,
+        variables: MaybeTakesApp[[_T], dict[str, Any]] | None = None,
+        converters: dict[str, Any] | None = None,
+        required: Collection[str] | None = None,
+        get_converters: Callable[[], dict[str, Any]] | None = None,
+        absorb: bool = False,
+    ) -> None:
+        self.model: type[Any] | None = model
         self.path = path
-        self.variables = variables
+        self.variables: MaybeTakesApp[[Any], dict[str, Any]] | None = variables
         self.converters = converters
         self.required = required
         self.get_converters = get_converters
         self.absorb = absorb
 
-    def identifier(self, path_registry):
+    def identifier(self, path_registry: PathRegistry) -> tuple[str, str]:
         return ("path", Path(self.path).discriminator())
 
-    def discriminators(self, path_registry):
+    def discriminators(
+        self, path_registry: PathRegistry
+    ) -> list[tuple[str, type[Any] | None]]:
         return [("model", self.model)]
 
-    def perform(self, obj, path_registry):
+    def perform(
+        self, obj: Callable[..., Any], path_registry: PathRegistry
+    ) -> None:
         path_registry.register_path(
             self.model,
             self.path,
@@ -360,14 +420,14 @@ class PathCompositeAction(dectate.Composite):
 
     def __init__(
         self,
-        path,
-        model=None,
-        variables=None,
-        converters=None,
-        required=None,
-        get_converters=None,
-        absorb=False,
-    ):
+        path: str,
+        model: type[Any] | None = None,
+        variables: MaybeTakesApp[[Any], dict[str, Any]] | None = None,
+        converters: dict[str, Any] | None = None,
+        required: Collection[str] | None = None,
+        get_converters: Callable[[], dict[str, Any]] | None = None,
+        absorb: bool = False,
+    ) -> None:
         """Register a model for a path.
 
         Decorate a function or a class (constructor). The function
@@ -415,7 +475,7 @@ class PathCompositeAction(dectate.Composite):
         self.get_converters = get_converters
         self.absorb = absorb
 
-    def actions(self, obj):
+    def actions(self, obj: _T) -> Generator[tuple[PathAction, _T]]:
         # this composite action exists to let you use path with a
         # class and still have the path action discriminator work
         # correctly, which reports a conflict if you use the path
@@ -462,7 +522,12 @@ class PermissionRuleAction(dectate.Action):
 
     depends = [SettingAction]
 
-    def __init__(self, model, permission, identity=Identity):
+    def __init__(
+        self,
+        model: type[Any],
+        permission: Any,
+        identity: type[Identity | NoIdentity] | None = Identity,
+    ) -> None:
         """Declare whether a model has a permission.
 
         The decorated function receives ``app``, ``model``,
@@ -485,10 +550,12 @@ class PermissionRuleAction(dectate.Action):
             identity = NoIdentity
         self.identity = identity
 
-    def identifier(self, app_class):
+    def identifier(
+        self, app_class: type[dectate.App]
+    ) -> tuple[type[Any], Any, type[Identity | NoIdentity]]:
         return (self.model, self.permission, self.identity)
 
-    def perform(self, obj, app_class):
+    def perform(self, obj: Callable[..., Any], app_class: type[App]) -> None:
         app_class._permits.register(
             methodify(obj, selfname="app"),
             identity=self.identity,
@@ -512,7 +579,12 @@ class TemplateDirectoryAction(dectate.Action):
         "before": dectate.convert_dotted_name,
     }
 
-    def __init__(self, after=None, before=None, name=None):
+    def __init__(
+        self,
+        after: GetStrPath | None = None,
+        before: GetStrPath | None = None,
+        name: str | None = None,
+    ) -> None:
         """Register template directory.
 
         The decorated function gets no argument and should return a
@@ -546,18 +618,26 @@ class TemplateDirectoryAction(dectate.Action):
             template_directory_id += 1
         self.name = name
 
-    def identifier(self, template_engine_registry):
+    def identifier(
+        self, template_engine_registry: TemplateEngineRegistry
+    ) -> str:
         return self.name
 
-    def perform(self, obj, template_engine_registry):
+    def perform(
+        self,
+        obj: Callable[[], StrPath],
+        template_engine_registry: TemplateEngineRegistry,
+    ) -> None:
         directory = obj()
         if not os.path.isabs(directory):
+            assert self.code_info is not None
             directory = os.path.join(
                 os.path.dirname(self.code_info.path), directory
             )
         # hacky to have to get configurable and pass it in.
         # note that this cannot be app_class as we want the app of
         # the directive that *defined* it so we sort things properly.
+        assert self.directive is not None
         template_engine_registry.register_template_directory_info(
             obj,
             directory,
@@ -572,7 +652,7 @@ class TemplateLoaderAction(dectate.Action):
 
     depends = [TemplateDirectoryAction]
 
-    def __init__(self, extension):
+    def __init__(self, extension: str) -> None:
         """Create a template loader.
 
         The decorated function gets a ``template_directories`` argument,
@@ -585,10 +665,19 @@ class TemplateLoaderAction(dectate.Action):
         """
         self.extension = extension
 
-    def identifier(self, template_engine_registry):
+    def identifier(
+        self, template_engine_registry: TemplateEngineRegistry
+    ) -> str:
         return self.extension
 
-    def perform(self, obj, template_engine_registry):
+    def perform(
+        self,
+        # NOTE: While list[StrPath] is the correct constraint, it might
+        #       be too strict if someone's application only ever uses
+        #       plain strings for paths, so we're being more forgiving.
+        obj: Callable[[list[Any], SettingRegistry], Any],
+        template_engine_registry: TemplateEngineRegistry,
+    ) -> None:
         template_engine_registry.initialize_template_loader(self.extension, obj)
 
 
@@ -597,7 +686,7 @@ class TemplateRenderAction(dectate.Action):
 
     depends = [SettingAction, TemplateLoaderAction]
 
-    def __init__(self, extension):
+    def __init__(self, extension: str) -> None:
         """Register a template engine.
 
         :param extension: the template file extension (``.pt``, etc)
@@ -613,14 +702,20 @@ class TemplateRenderAction(dectate.Action):
         """
         self.extension = extension
 
-    def identifier(self, template_engine_registry):
+    def identifier(
+        self, template_engine_registry: TemplateEngineRegistry
+    ) -> str:
         return self.extension
 
-    def perform(self, obj, template_engine_registry):
+    def perform(
+        self,
+        obj: Callable[..., Any],
+        template_engine_registry: TemplateEngineRegistry,
+    ) -> None:
         template_engine_registry.register_template_render(self.extension, obj)
 
 
-def issubclass_or_none(a, b):
+def issubclass_or_none(a: type | None, b: type | None) -> bool:
     if a is None or b is None:
         return a == b
     return issubclass(a, b)
@@ -641,7 +736,7 @@ class ViewAction(dectate.Action):
         "internal": dectate.convert_bool,
     }
 
-    def filter_get_value(self, name):
+    def filter_get_value(self, name: str) -> Any | dectate.Sentinel:
         return self.predicates.get(name, dectate.NOT_FOUND)
 
     filter_compare = {
@@ -653,14 +748,14 @@ class ViewAction(dectate.Action):
 
     def __init__(
         self,
-        model,
-        render=None,
-        template=None,
-        load=None,
-        permission=None,
-        internal=False,
-        **predicates,
-    ):
+        model: type[Any],
+        render: Callable[[Any, AnyRequest], BaseResponse] | None = None,
+        template: str | None = None,
+        load: Callable[[AnyRequest], Any] | None = None,
+        permission: object | None = None,
+        internal: bool = False,
+        **predicates: Any,
+    ) -> None:
         """Register a view for a model.
 
         The decorated function gets ``self`` (model instance) and
@@ -722,17 +817,26 @@ class ViewAction(dectate.Action):
         self.internal = internal
         self.predicates = predicates
 
-    def key_dict(self):
+    def key_dict(self) -> dict[str, Any]:
         """Return a dict containing view registration info,
         for instance model, request_method, etc."""
         result = self.predicates.copy()
         result["model"] = self.model
         return result
 
-    def identifier(self, template_engine_registry, app_class):
+    def identifier(
+        self,
+        template_engine_registry: TemplateEngineRegistry,
+        app_class: type[App],
+    ) -> tuple[Any, ...]:
         return app_class.get_view.by_predicates(**self.key_dict()).key
 
-    def perform(self, obj, template_engine_registry, app_class):
+    def perform(
+        self,
+        obj: Callable[..., Any],
+        template_engine_registry: TemplateEngineRegistry,
+        app_class: type[App],
+    ) -> None:
         render = self.render
         if self.template is not None:
             render = template_engine_registry.get_template_render(
@@ -754,13 +858,13 @@ class JsonAction(ViewAction):
 
     def __init__(
         self,
-        model,
-        render=None,
-        template=None,
-        load=None,
-        permission=None,
-        internal=False,
-        **predicates,
+        model: type[Any],
+        render: Callable[[Any, AnyRequest], BaseResponse] | None = None,
+        template: str | None = None,
+        load: Callable[[AnyRequest], Any] | None = None,
+        permission: object | None = None,
+        internal: bool = False,
+        **predicates: Any,
     ):
         """Register JSON view.
 
@@ -816,13 +920,13 @@ class HtmlAction(ViewAction):
 
     def __init__(
         self,
-        model,
-        render=None,
-        template=None,
-        load=None,
-        permission=None,
-        internal=False,
-        **predicates,
+        model: type[Any],
+        render: Callable[[Any, AnyRequest], BaseResponse] | None = None,
+        template: str | None = None,
+        load: Callable[[AnyRequest], Any] | None = None,
+        permission: object | None = None,
+        internal: bool = False,
+        **predicates: Any,
     ):
         """Register HTML view.
 
@@ -878,6 +982,7 @@ class DummyModel:
 
 
 class MountAction(PathAction):
+    variables: Callable[[AnyApp], dict[str, Any]]  # pyright: ignore
     group_class = PathAction
     depends = [SettingAction, ConverterAction]
 
@@ -886,14 +991,14 @@ class MountAction(PathAction):
 
     def __init__(
         self,
-        path,
-        app,
-        variables=None,
-        converters=None,
-        required=None,
-        get_converters=None,
-        name=None,
-    ):
+        path: str,
+        app: type[_AppT],
+        variables: Callable[[_AppT], dict[str, Any]] | None = None,
+        converters: dict[str, Any] | None = None,
+        required: Collection[str] | None = None,
+        get_converters: Callable[[], dict[str, Any]] | None = None,
+        name: str | None = None,
+    ) -> None:
         """Mount sub application on path.
 
         The decorated function gets the variables specified in path as
@@ -925,7 +1030,10 @@ class MountAction(PathAction):
         super().__init__(
             path,
             model=DummyModel,
-            variables=variables,
+            # NOTE: This is safe because we override perform to not make
+            #       use of model, so it doesn't matter that the variables
+            #       callback accepts a different kind of object.
+            variables=variables,  # type: ignore[arg-type]
             converters=converters,
             required=required,
             get_converters=get_converters,
@@ -933,10 +1041,14 @@ class MountAction(PathAction):
         self.name = name or path
         self.app = app
 
-    def discriminators(self, path_registry):
+    def discriminators(
+        self, path_registry: PathRegistry
+    ) -> list[tuple[str, type[Any] | None]]:
         return [("mount", self.app)]
 
-    def perform(self, obj, path_registry):
+    def perform(
+        self, obj: Callable[..., Any], path_registry: PathRegistry
+    ) -> None:
         path_registry.register_mount(
             self.app,
             self.path,
@@ -958,7 +1070,7 @@ class DeferLinksAction(dectate.Action):
 
     filter_compare = {"model": isbaseclass}
 
-    def __init__(self, model):
+    def __init__(self, model: type[Any]) -> None:
         """Defer link generation for model to mounted app.
 
         With ``defer_links`` you can specify that link generation for
@@ -981,13 +1093,15 @@ class DeferLinksAction(dectate.Action):
         """
         self.model = model
 
-    def identifier(self, path_registry):
+    def identifier(self, path_registry: PathRegistry) -> tuple[str, type[Any]]:
         return ("defer_links", self.model)
 
-    def discriminators(self, path_registry):
+    def discriminators(
+        self, path_registry: PathRegistry
+    ) -> list[tuple[str, type[Any]]]:
         return [("model", self.model)]
 
-    def perform(self, obj, path_registry):
+    def perform(self, obj: Any, path_registry: PathRegistry) -> None:
         path_registry.register_defer_links(self.model, obj)
 
 
@@ -999,7 +1113,11 @@ class DeferClassLinksAction(dectate.Action):
 
     filter_compare = {"model": isbaseclass}
 
-    def __init__(self, model, variables):
+    def __init__(
+        self,
+        model: type[Any],
+        variables: Callable[[Any], dict[str, Any]],
+    ) -> None:
         """Defer class link generation for model class to mounted app.
 
         With ``defer_class_links`` you can specify that link
@@ -1030,15 +1148,19 @@ class DeferClassLinksAction(dectate.Action):
         self.model = model
         self.variables = variables
 
-    def identifier(self, path_registry):
+    def identifier(self, path_registry: PathRegistry) -> tuple[str, type[Any]]:
         # either implement defer_links for a model or implement
         # defer_class_links but not both
         return ("defer_links", self.model)
 
-    def discriminators(self, path_registry):
+    def discriminators(
+        self, path_registry: PathRegistry
+    ) -> list[tuple[str, type[Any]]]:
         return [("model", self.model)]
 
-    def perform(self, obj, path_registry):
+    def perform(
+        self, obj: Callable[..., Any], path_registry: PathRegistry
+    ) -> None:
         path_registry.register_defer_class_links(
             self.model, self.variables, obj
         )
@@ -1057,7 +1179,12 @@ class TweenFactoryAction(dectate.Action):
         "over": dectate.convert_dotted_name,
     }
 
-    def __init__(self, under=None, over=None, name=None):
+    def __init__(
+        self,
+        under: TweenFactory | None = None,
+        over: TweenFactory | None = None,
+        name: str | None = None,
+    ) -> None:
         """Register tween factory.
 
         The tween system allows the creation of lightweight middleware
@@ -1090,10 +1217,10 @@ class TweenFactoryAction(dectate.Action):
             tween_factory_id += 1
         self.name = name
 
-    def identifier(self, tween_registry):
+    def identifier(self, tween_registry: TweenRegistry) -> str:
         return self.name
 
-    def perform(self, obj, tween_registry):
+    def perform(self, obj: TweenFactory, tween_registry: TweenRegistry) -> None:
         tween_registry.register_tween_factory(
             obj, over=self.over, under=self.under
         )
@@ -1108,7 +1235,7 @@ class IdentityPolicyAction(dectate.Action):
 
     app_class_arg = True
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Register identity policy.
 
         The decorated function should return an instance of
@@ -1119,16 +1246,22 @@ class IdentityPolicyAction(dectate.Action):
         identity policy is in use. So you can pass some settings directly to
         the IdentityPolicy class.
         """
-        pass
 
-    def identifier(self, setting_registry, app_class):
+    def identifier(
+        self, setting_registry: SettingRegistry, app_class: type[dectate.App]
+    ) -> tuple[()]:
         return ()
 
-    def perform(self, obj, setting_registry, app_class):
+    def perform(
+        self,
+        obj: Callable[..., Any],
+        setting_registry: SettingRegistry,
+        app_class: type[App],
+    ) -> None:
         identity_policy = mapply(obj, settings=setting_registry)
-        app_class._identify = identity_policy.identify
-        app_class.remember_identity = identity_policy.remember
-        app_class.forget_identity = identity_policy.forget
+        app_class._identify = identity_policy.identify  # type: ignore[method-assign]
+        app_class.remember_identity = identity_policy.remember  # type: ignore[method-assign]
+        app_class.forget_identity = identity_policy.forget  # type: ignore[method-assign]
 
 
 class VerifyIdentityAction(dectate.Action):
@@ -1142,7 +1275,7 @@ class VerifyIdentityAction(dectate.Action):
         "identity": dectate.convert_dotted_name,
     }
 
-    def __init__(self, identity=object):
+    def __init__(self, identity: type[Any] = object) -> None:
         """Verify claimed identity.
 
         The decorated function takes an ``app`` argument and an
@@ -1166,10 +1299,10 @@ class VerifyIdentityAction(dectate.Action):
         """
         self.identity = identity
 
-    def identifier(self, app_class):
+    def identifier(self, app_class: type[App]) -> object:
         return self.identity
 
-    def perform(self, obj, app_class):
+    def perform(self, obj: Callable[..., Any], app_class: type[App]) -> None:
         app_class._verify_identity.register(
             methodify(obj, selfname="app"), identity=self.identity
         )
@@ -1184,7 +1317,7 @@ class DumpJsonAction(dectate.Action):
 
     app_class_arg = True
 
-    def __init__(self, model=object):
+    def __init__(self, model: type[Any] = object) -> None:
         """Register a function that converts model to JSON.
 
         The decorated function gets ``app`` (app instance), ``obj``
@@ -1200,10 +1333,10 @@ class DumpJsonAction(dectate.Action):
         """
         self.model = model
 
-    def identifier(self, app_class):
+    def identifier(self, app_class: type[App]) -> type[Any]:
         return self.model
 
-    def perform(self, obj, app_class):
+    def perform(self, obj: Callable[..., Any], app_class: type[App]) -> None:
         app_class._dump_json.register(
             methodify(obj, selfname="app"), obj=self.model
         )
@@ -1214,7 +1347,7 @@ class LinkPrefixAction(dectate.Action):
 
     app_class_arg = True
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Register a function that returns the prefix added to every link
         generated by the request.
 
@@ -1225,10 +1358,9 @@ class LinkPrefixAction(dectate.Action):
         (:class:`morepath.Request`) arguments. The ``app`` argument is
         optional. The function should return a string.
         """
-        pass
 
-    def identifier(self, app_class):
+    def identifier(self, app_class: type[App]) -> tuple[()]:
         return ()
 
-    def perform(self, obj, app_class):
-        app_class._link_prefix = methodify(obj, selfname="app")
+    def perform(self, obj: Callable[..., Any], app_class: type[App]) -> None:
+        app_class._link_prefix = methodify(obj, selfname="app")  # type: ignore[method-assign]

--- a/morepath/error.py
+++ b/morepath/error.py
@@ -15,9 +15,11 @@ Dectate:
 """
 
 # -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import textwrap
 
-from dectate import (  # noqa F401
+from dectate import (
     ConfigError,
     ConflictError,
     DirectiveError,
@@ -25,12 +27,23 @@ from dectate import (  # noqa F401
     TopologicalSortError,
 )
 
+__all__ = (
+    "AutoImportError",
+    "ConfigError",
+    "ConflictError",
+    "DirectiveError",
+    "DirectiveReportError",
+    "LinkError",
+    "TopologicalSortError",
+    "TrajectError",
+)
+
 
 # XXX is ConfigError the right base class?
 class AutoImportError(ConfigError):
     """Raised when Morepath fails to import a module during autoscan."""
 
-    def __init__(self, module_name):
+    def __init__(self, module_name: str) -> None:
 
         msg = """\
             Morepath wanted to import '{}' during auto-configuration, but

--- a/morepath/mapply.py
+++ b/morepath/mapply.py
@@ -1,7 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, TypeVar
+
 from reg import arginfo
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
-def mapply(func, *args, **kw):
+_T = TypeVar("_T")
+
+
+def mapply(func: Callable[..., _T], *args: Any, **kw: Any) -> _T:
     """Apply keyword arguments to function only if it defines them.
 
     So this works without error as ``b`` is ignored::
@@ -16,8 +25,10 @@ def mapply(func, *args, **kw):
     function/method that we've borrowed.
     """
     info = arginfo(func)
+    assert info is not None
     if info.varkw:
         return func(*args, **kw)
     # XXX we don't support nested arguments
+    # FIXME: we don't support keyword-only arguments
     new_kw = {name: kw[name] for name in info.args if name in kw}
     return func(*args, **new_kw)

--- a/morepath/path.py
+++ b/morepath/path.py
@@ -5,6 +5,10 @@ This builds on :mod:`morepath.traject`.
 See also :class:`morepath.directive.PathRegistry`
 """
 
+from __future__ import annotations
+
+from itertools import zip_longest
+from typing import TYPE_CHECKING, Any, TypeVar
 from urllib.parse import quote, urlencode
 
 from dectate import DirectiveError
@@ -14,6 +18,17 @@ from .converter import IDENTITY_CONVERTER, ConverterRegistry
 from .error import LinkError
 from .traject import Path as TrajectPath
 from .traject import TrajectRegistry
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Collection
+
+    from dectate import CodeInfo
+
+    from .app import App
+    from .types import AnyConverter, MaybeTakesApp
+
+_T = TypeVar("_T")
+_AppT = TypeVar("_AppT", bound="App")
 
 SPECIAL_ARGUMENTS = ["request", "app"]
 
@@ -37,25 +52,27 @@ class PathRegistry(TrajectRegistry):
 
     app_class_arg = True
 
-    def __init__(self, app_class, converter_registry):
+    def __init__(
+        self, app_class: type[App], converter_registry: ConverterRegistry
+    ) -> None:
         super().__init__()
         self.app_class = app_class
         self.converter_registry = converter_registry
-        self.mounted = {}
-        self.named_mounted = {}
+        self.mounted: dict[type[App], Callable[..., App]] = {}
+        self.named_mounted: dict[str, Callable[..., App]] = {}
 
     def register_path(
         self,
-        model,
-        path,
-        variables,
-        converters,
-        required,
-        get_converters,
-        absorb,
-        code_info,
-        model_factory,
-    ):
+        model: type[_T] | None,
+        path: str,
+        variables: MaybeTakesApp[[_T], dict[str, Any]] | None,
+        converters: dict[str, Any] | None,
+        required: Collection[str] | None,
+        get_converters: Callable[[], dict[str, Any]] | None,
+        absorb: bool,
+        code_info: CodeInfo | None,
+        model_factory: Callable[..., Any],
+    ) -> None:
         """Register a route.
 
         See :meth:`morepath.App.path` for more information.
@@ -82,6 +99,7 @@ class PathRegistry(TrajectRegistry):
         )
 
         info = arginfo(model_factory)
+        assert info is not None
         if info.varargs is not None:
             raise DirectiveError(
                 "Cannot use varargs in function signature: %s" % info.varargs
@@ -125,16 +143,16 @@ class PathRegistry(TrajectRegistry):
 
     def register_mount(
         self,
-        app,
-        path,
-        variables,
-        converters,
-        required,
-        get_converters,
-        mount_name,
-        code_info,
-        app_factory,
-    ):
+        app: type[_AppT],
+        path: str,
+        variables: Callable[[_AppT], dict[str, Any]] | None,
+        converters: dict[str, Any] | None,
+        required: Collection[str] | None,
+        get_converters: Callable[[], dict[str, Any]] | None,
+        mount_name: str,
+        code_info: CodeInfo | None,
+        app_factory: Callable[..., App],
+    ) -> None:
         """Register a mounted app.
 
         See :meth:`morepath.App.mount` for more information.
@@ -168,7 +186,11 @@ class PathRegistry(TrajectRegistry):
         mount_name = mount_name or path
         self.named_mounted[mount_name] = app_factory
 
-    def register_path_variables(self, model, func):
+    def register_path_variables(
+        self,
+        model: type[_T] | None,
+        func: MaybeTakesApp[[_T], dict[str, Any]],
+    ) -> None:
         """Register variables function for a model class.
 
         :param model: model class
@@ -180,8 +202,13 @@ class PathRegistry(TrajectRegistry):
         )
 
     def register_inverse_path(
-        self, model, path, factory_args, converters=None, absorb=False
-    ):
+        self,
+        model: type[Any] | None,
+        path: str,
+        factory_args: Collection[str],
+        converters: dict[str, AnyConverter] | None = None,
+        absorb: bool = False,
+    ) -> None:
         """Register information for link generation.
 
         :param model: model class
@@ -196,14 +223,16 @@ class PathRegistry(TrajectRegistry):
 
         self.app_class._class_path.register(get_path, model=model)
 
-        def default_path_variables(app, obj):
+        def default_path_variables(app: App, obj: Any) -> dict[str, Any]:
             return {name: getattr(obj, name) for name in factory_args}
 
         self.app_class._default_path_variables.register(
             default_path_variables, obj=model
         )
 
-    def register_defer_links(self, model, app_factory):
+    def register_defer_links(
+        self, model: type[_T], app_factory: Callable[..., App]
+    ) -> None:
         """Register factory for app to defer links to.
 
         See :meth:`morepath.App.defer_links` for more information.
@@ -215,14 +244,19 @@ class PathRegistry(TrajectRegistry):
         """
         self.app_class._deferred_link_app.register(app_factory, obj=model)
 
-    def register_defer_class_links(self, model, get_variables, app_factory):
+    def register_defer_class_links(
+        self,
+        model: type[_T],
+        get_variables: Callable[[_T], dict[str, Any]],
+        app_factory: Callable[..., App],
+    ) -> None:
         """Register factory for app to defer class links to.
 
         See :meth:`morepath.App.defer_class_links` for more information.
 
         :param model: model class to defer links for.
         :param get_variables: get variables dict for obj.
-        :param app_factory: function that model class, app instance
+        :param app_factory: function that takes model class, app instance
           and variables dict as arguments and should return another
           app instance that does the link generation.
         """
@@ -239,11 +273,11 @@ class PathInfo:
     :param parameters: a dict representing URL parameters.
     """
 
-    def __init__(self, path, parameters):
+    def __init__(self, path: str, parameters: dict[str, list[str]]) -> None:
         self.path = path
         self.parameters = parameters
 
-    def url(self, prefix, name):
+    def url(self, prefix: str, name: str) -> str:
         """Turn a path into a URL.
 
         :param prefix: the URL prefix to put in front of the path. This
@@ -269,7 +303,7 @@ class PathInfo:
                 (key, [v.encode("utf-8") for v in value])
                 for (key, value) in self.parameters.items()
             )
-            result += "?" + fixed_urlencode(parameters, True)
+            result += "?" + urlencode(parameters, True)
         return result
 
 
@@ -285,7 +319,13 @@ class Path:
     :param absorb: bool indicating this is an absorbing path.
     """
 
-    def __init__(self, path, factory_args, converters, absorb):
+    def __init__(
+        self,
+        path: str,
+        factory_args: Collection[str],
+        converters: dict[str, AnyConverter],
+        absorb: bool,
+    ) -> None:
         self.path = path
         traject_path = TrajectPath(path)
         self.interpolation_path = traject_path.interpolation_str()
@@ -296,7 +336,9 @@ class Path:
         self.converters = converters
         self.absorb = absorb
 
-    def get_variables_and_parameters(self, variables, extra_parameters):
+    def get_variables_and_parameters(
+        self, variables: dict[str, Any], extra_parameters: dict[str, Any]
+    ) -> tuple[dict[str, str], dict[str, list[str]]]:
         """Get converted variables and parameters.
 
         :param variables: dict of variables to use in the path.
@@ -332,7 +374,9 @@ class Path:
                 ).encode(value)
         return path_variables, parameters
 
-    def __call__(self, app, model, variables):
+    def __call__(
+        self, app: App, model: type[object], variables: dict[str, Any]
+    ) -> PathInfo:
         """Get path info given model and variables.
 
         :param app: the app instance. Not actually used in the
@@ -368,7 +412,9 @@ class Path:
         return PathInfo(path, url_parameters)
 
 
-def get_arguments(callable, exclude):
+def get_arguments(
+    callable: Callable[..., Any], exclude: Collection[str]
+) -> dict[str, Any]:
     """Introspect callable to get callable arguments and their defaults.
 
     :param callable: callable object such as a function.
@@ -377,16 +423,20 @@ def get_arguments(callable, exclude):
        default values (or ``None`` if no default value was defined).
     """
     info = arginfo(callable)
-    defaults = info.defaults or []
-    defaults = [None] * (len(info.args) - len(defaults)) + list(defaults)
+    assert info is not None
+    defaults = info.defaults or ()
     return {
         name: default
-        for (name, default) in zip(info.args, defaults)
+        for (name, default) in zip_longest(
+            reversed(info.args), reversed(defaults)
+        )
         if name not in exclude
     }
 
 
-def filter_arguments(arguments, exclude):
+def filter_arguments(
+    arguments: dict[str, Any], exclude: Collection[str]
+) -> dict[str, Any]:
     """Filter arguments.
 
     Given a dictionary with arguments and defaults, filter out
@@ -401,15 +451,3 @@ def filter_arguments(arguments, exclude):
         for (name, default) in arguments.items()
         if name not in exclude
     }
-
-
-def fixed_urlencode(s, doseq=0):
-    """``urllib.urlencode`` fixed for ``~``
-
-    Workaround for Python bug:
-
-    https://bugs.python.org/issue16285
-
-    tilde should not be encoded according to RFC3986
-    """
-    return urlencode(s, doseq).replace("%7E", "~")

--- a/morepath/pdbsupport.py
+++ b/morepath/pdbsupport.py
@@ -1,11 +1,14 @@
+from __future__ import annotations
+
 from pdb import Pdb  # pragma: nocoverage
+from typing import Any
 
 morepath_pdb = Pdb(
     skip=["reg.*", "inspect", "repoze.lru"]
 )  # pragma: nocoverage
 
 
-def set_trace(*args, **kw):  # pragma: nocoverage
+def set_trace(*args: Any, **kw: Any) -> None:  # pragma: nocoverage
     """Set pdb trace as in ``import pdb; pdb.set_trace``, ignores ``reg``.
 
     Use ``from morepath import pdbsupport; pdbsupport.set_trace()`` to use.

--- a/morepath/predicate.py
+++ b/morepath/predicate.py
@@ -10,11 +10,22 @@ predicates.
 See also :class:`morepath.directive.PredicateRegistry`
 """
 
+from __future__ import annotations
+
 from collections import defaultdict
+from typing import TYPE_CHECKING, Any
 
 from reg import Predicate
 
 from .toposort import Info, toposorted
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from reg.predicate import KeyIndex
+    from reg.types import DispatchCall
+
+    from .app import App
 
 
 class PredicateRegistry:
@@ -26,14 +37,26 @@ class PredicateRegistry:
 
     app_class_arg = True
 
-    def __init__(self, app_class):
+    def __init__(self, app_class: type[App]) -> None:
         self.app_class = app_class
-        self._predicate_infos = defaultdict(list)
-        self._predicate_fallbacks = defaultdict(dict)
+        self._predicate_infos: dict[
+            DispatchCall[..., Any], list[PredicateInfo]
+        ] = defaultdict(list)
+        self._predicate_fallbacks: dict[
+            DispatchCall[..., Any] | str,
+            dict[Callable[..., Any] | str, Callable[..., Any]],
+        ] = defaultdict(dict)
 
     def register_predicate(
-        self, func, dispatch, name, default, index, before, after
-    ):
+        self,
+        func: Callable[..., Any],
+        dispatch: DispatchCall[..., Any],
+        name: str,
+        default: Any,
+        index: Callable[[Callable[..., Any] | None], KeyIndex],
+        before: Callable[..., Any] | None,
+        after: Callable[..., Any] | None,
+    ) -> None:
         """Register a predicate for installation into the reg registry.
 
         See :meth:`morepath.App.predicate` for details.
@@ -49,7 +72,12 @@ class PredicateRegistry:
         info = PredicateInfo(func, name, default, index, before, after)
         self._predicate_infos[dispatch].append(info)
 
-    def register_predicate_fallback(self, dispatch, func, fallback_func):
+    def register_predicate_fallback(
+        self,
+        dispatch: DispatchCall[..., Any] | str,
+        func: Callable[..., Any] | str,
+        fallback_func: Callable[..., Any],
+    ) -> None:
         """Register a predicate fallback for installation into reg registry.
 
         See :meth:`morepath.App.predicate_fallback` for details.
@@ -60,7 +88,7 @@ class PredicateRegistry:
         """
         self._predicate_fallbacks[dispatch][func] = fallback_func
 
-    def install_predicates(self):
+    def install_predicates(self) -> None:
         """Install the predicates with reg.
 
         This should be called during configuration once all predicates
@@ -73,7 +101,9 @@ class PredicateRegistry:
                 self.get_predicates(dispatch)
             )
 
-    def get_predicates(self, dispatch):
+    def get_predicates(
+        self, dispatch: DispatchCall[..., Any]
+    ) -> list[Predicate]:
         """Create Reg predicates.
 
         This creates :class:`reg.Predicate` objects for a particular
@@ -101,7 +131,9 @@ class PredicateRegistry:
             result.append(predicate)
         return result
 
-    def sorted_predicate_infos(self, dispatch):
+    def sorted_predicate_infos(
+        self, dispatch: DispatchCall[..., Any]
+    ) -> list[PredicateInfo]:
         """Topologically sort predicate infos for a dispatch function.
 
         :param dispatch: the dispatch function to sort for.
@@ -110,21 +142,29 @@ class PredicateRegistry:
         return toposorted(self._predicate_infos[dispatch])
 
 
-def adapt(func):
-    def wrapper(d):
+def adapt(func: Callable[..., Any]) -> Callable[[dict[str, Any]], Any]:
+    def wrapper(d: dict[str, Any]) -> Any:
         return func(**d)
 
     return wrapper
 
 
-class PredicateInfo(Info):
+class PredicateInfo(Info["Callable[..., Any]"]):
     """Used by :class:`PredicateRegistry` internally.
 
     Is used to store registration information on a predicate
     before it is registered with Reg.
     """
 
-    def __init__(self, func, name, default, index, before, after):
+    def __init__(
+        self,
+        func: Callable[..., Any],
+        name: str,
+        default: Any,
+        index: Callable[[Callable[..., Any] | None], KeyIndex],
+        before: Callable[..., Any] | None,
+        after: Callable[..., Any] | None,
+    ):
         super().__init__(func, before, after)
         self.func = func
         self.name = name

--- a/morepath/publish.py
+++ b/morepath/publish.py
@@ -15,14 +15,25 @@ The publish module:
 It all starts at :func:`publish`.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from webob.exc import HTTPNotFound
 
 from .app import App
 
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from webob.response import Response as BaseResponse
+
+    from .request import Request
+
 DEFAULT_NAME = ""
 
 
-def publish(request):
+def publish(request: Request) -> BaseResponse:
     """Handle request and return response.
 
     It uses :func:`resolve_model` to use the information in
@@ -38,7 +49,7 @@ def publish(request):
     return resolve_response(obj, request)
 
 
-def resolve_model(request):
+def resolve_model(request: Request) -> Any | None:
     """Resolve request to a model object.
 
     This takes the path information as a stack of path segments in
@@ -71,7 +82,7 @@ def resolve_model(request):
     return app.config.path_registry.consume(request)
 
 
-def resolve_response(obj, request):
+def resolve_response(obj: object, request: Request) -> BaseResponse:
     """Given model object and request, create response.
 
     This uses :func:`get_view_name` to set up the view name on the
@@ -93,7 +104,7 @@ def resolve_response(obj, request):
     return request.app.get_view(obj, request)
 
 
-def get_view_name(stack):
+def get_view_name(stack: Sequence[str]) -> str | None:
     """Determine view name from leftover stack of path segments
 
     :param stack: a list of path segments left over after consuming

--- a/morepath/reify.py
+++ b/morepath/reify.py
@@ -1,7 +1,16 @@
 # Originally taken from pyramid.decorator
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, overload
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing_extensions import Self
+
+_T = TypeVar("_T")
 
 
-class reify:
+class reify(Generic[_T]):
     """Cache a property.
 
     Use as a method decorator.  It operates almost exactly like the
@@ -34,11 +43,22 @@ class reify:
 
     """
 
-    def __init__(self, wrapped):
+    def __init__(self, wrapped: Callable[[Any], _T]) -> None:
         self.wrapped = wrapped
         self.__doc__ = wrapped.__doc__
 
-    def __get__(self, inst, objtype=None):
+    @overload
+    def __get__(
+        self, inst: None, objtype: type[object] | None = None
+    ) -> Self: ...
+    @overload
+    def __get__(
+        self, inst: object, objtype: type[object] | None = None
+    ) -> _T: ...
+
+    def __get__(
+        self, inst: object | None, objtype: type[object] | None = None
+    ) -> Self | _T:
         if inst is None:
             return self
         val = self.wrapped(inst)

--- a/morepath/request.py
+++ b/morepath/request.py
@@ -4,6 +4,10 @@ Entirely documented in :class:`morepath.Request` and
 :class:`morepath.Response` in the public API.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Generic, cast, overload
+
 from webob import Response as BaseResponse
 from webob.request import BaseRequest
 
@@ -14,19 +18,49 @@ from .error import LinkError
 from .reify import reify
 from .traject import create_path, parse_path
 
-SAME_APP = Sentinel("SAME_APP")
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing_extensions import TypeVar
+
+    from dectate import CodeInfo
+
+    from .app import App
+    from .authentication import Identity, NoIdentity
+    from .types import WSGIEnvironment
+    from .view import View
+
+    _AppT = TypeVar("_AppT", bound="App", default="App", covariant=True)
+else:
+    from typing import TypeVar
+
+    _AppT = TypeVar("_AppT", bound="App", covariant=True)
 
 
-class Request(BaseRequest):
+_T = TypeVar("_T")
+# NOTE: Technically `webob.Response` is the correct bound, since we're not
+#       guaranteed to always get a `morepath.Response`, but considering
+#       that `morepath.Response` does not add any attributes of its own,
+#       the improved ergonomics of being able to annotate as either
+#       `webob.Response` or `morepath.Response` interchangeably outweigh
+#       the risks of `morepath.Response` being inaccurate in some
+#       cirumstances.
+_AfterT = TypeVar("_AfterT", bound="Callable[[Response], object]")
+
+SAME_APP: Sentinel = Sentinel("SAME_APP")
+
+
+class Request(BaseRequest, Generic[_AppT]):
     """Request.
 
     Extends :class:`webob.request.BaseRequest`
     """
 
-    path_code_info = None
-    view_code_info = None
+    app: _AppT
+    path_code_info: CodeInfo | None = None
+    view_code_info: CodeInfo | None = None
+    view_name: str | None = None
 
-    def __init__(self, environ, app, **kw):
+    def __init__(self, environ: WSGIEnvironment, app: _AppT, **kw: Any) -> None:
         super().__init__(environ, **kw)
         # parse path, normalizing dots away in
         # in case the client didn't do the normalization
@@ -51,10 +85,10 @@ class Request(BaseRequest):
         self.app = app
         """:class:`morepath.App` instance currently handling request.
         """
-        self._after = []
-        self._link_prefix_cache = {}
+        self._after: list[Callable[[BaseResponse], object]] = []
+        self._link_prefix_cache: dict[type[object], str] = {}
 
-    def reset(self):
+    def reset(self) -> None:
         """Reset request.
 
         This resets the request back to the state it had when request
@@ -69,7 +103,7 @@ class Request(BaseRequest):
         self._after = []
 
     @reify
-    def identity(self):
+    def identity(self) -> Identity | NoIdentity:
         """Self-proclaimed identity of the user.
 
         The identity is established using the identity policy. Normally
@@ -85,11 +119,13 @@ class Request(BaseRequest):
         result = self.app._identify(self)
         if result is None or result is NO_IDENTITY:
             return NO_IDENTITY
+
+        result = cast("Identity", result)
         if not self.app._verify_identity(result):
             return NO_IDENTITY
         return result
 
-    def link_prefix(self, app=None):
+    def link_prefix(self, app: App | None = None) -> str:
         """Prefix to all links created by this request.
 
         :param app: Optionally use the given app to create the link.
@@ -107,7 +143,13 @@ class Request(BaseRequest):
 
         return prefix
 
-    def view(self, obj, default=None, app=SAME_APP, **predicates):
+    def view(
+        self,
+        obj: object,
+        default: _T | None = None,
+        app: App | Sentinel = SAME_APP,
+        **predicates: Any,
+    ) -> Any | _T | None:
         """Call view for model instance.
 
         This does not render the view, but calls the appropriate
@@ -131,24 +173,63 @@ class Request(BaseRequest):
         if app is SAME_APP:
             app = self.app
 
+        assert not isinstance(app, Sentinel)
         predicates["model"] = obj.__class__
 
-        def find(app, obj):
-            return app.get_view.by_predicates(**predicates).component
+        def find(app: App, obj: object) -> View | None:
+            # NOTE: The fact that this is always a view instance is very much an
+            #       implementation detail and relies on all views getting registered
+            #       by the view action, rather than manually through get_view.register
+            return cast(
+                "View | None",
+                app.get_view.by_predicates(**predicates).component,
+            )
 
-        view, app = app._follow_defers(find, obj)
+        view, found_app = app._follow_defers(find, obj)
         if view is None:
             return default
 
+        assert found_app is not None
         old_app = self.app
-        self.app = app
+        self.app = found_app  # type: ignore[assignment]
         # need to use value as view is registered as a function, not
         # as a wrapped method
-        result = view.func(obj, self)
-        self.app = old_app
+        try:
+            result = view.func(obj, self)
+        finally:
+            # Make sure we always restore the original bound app, even
+            # if the view throws an exception
+            self.app = old_app
         return result
 
-    def link(self, obj, name="", default=None, app=SAME_APP):
+    @overload
+    def link(  # pyright: ignore[reportOverlappingOverload]
+        self,
+        obj: None,
+        name: str = "",
+        default: None = None,
+        app: App | Sentinel = ...,
+    ) -> None: ...
+    @overload
+    def link(
+        self, obj: None, name: str, default: _T, app: App | Sentinel = ...
+    ) -> _T: ...
+    @overload
+    def link(
+        self,
+        obj: object,
+        name: str = "",
+        default: Any = None,
+        app: App | Sentinel = ...,
+    ) -> str: ...
+
+    def link(
+        self,
+        obj: object,
+        name: str = "",
+        default: Any = None,
+        app: App | Sentinel = SAME_APP,
+    ) -> Any | None:
         """Create a link (URL) to a view on a model instance.
 
         The resulting link is prefixed by the link prefix. By default
@@ -186,14 +267,21 @@ class Request(BaseRequest):
         if app is SAME_APP:
             app = self.app
 
-        info, app = app._get_deferred_mounted_path(obj)
+        assert not isinstance(app, Sentinel)
+        info, found_app = app._get_deferred_mounted_path(obj)
 
         if info is None:
             raise LinkError("Cannot link to: %r" % obj)
 
-        return info.url(self.link_prefix(app), name)
+        return info.url(self.link_prefix(found_app), name)
 
-    def class_link(self, model, variables=None, name="", app=SAME_APP):
+    def class_link(
+        self,
+        model: type,
+        variables: dict[str, Any] | None = None,
+        name: str = "",
+        app: App | Sentinel = SAME_APP,
+    ) -> str:
         """Create a link (URL) to a view on a class.
 
         Given a model class and a variables dictionary, create a link
@@ -240,6 +328,7 @@ class Request(BaseRequest):
         if app is SAME_APP:
             app = self.app
 
+        assert not isinstance(app, Sentinel)
         info = app._get_deferred_mounted_class_path(model, variables)
 
         if info is None:
@@ -247,7 +336,9 @@ class Request(BaseRequest):
 
         return info.url(self.link_prefix(), name)
 
-    def resolve_path(self, path, app=SAME_APP):
+    def resolve_path(
+        self, path: str, app: App | Sentinel = SAME_APP
+    ) -> Any | None:
         """Resolve a path to a model instance.
 
         The resulting object is a model instance, or ``None`` if the
@@ -265,13 +356,14 @@ class Request(BaseRequest):
         if app is SAME_APP:
             app = self.app
 
+        assert not isinstance(app, Sentinel)
         request = Request(self.environ.copy(), app, path_info=path)
         # try to resolve imports..
         from .publish import resolve_model
 
         return resolve_model(request)
 
-    def after(self, func):
+    def after(self, func: _AfterT) -> _AfterT:
         """Call a function with the response after a successful request.
 
         A request is considered *successful* if the HTTP status is a 2XX or a
@@ -309,10 +401,11 @@ class Request(BaseRequest):
         :param func: callable that is called with response
         :return: func argument, not wrapped
         """
-        self._after.append(func)
+        # NOTE: See the note on _AfterT
+        self._after.append(func)  # type: ignore[arg-type]
         return func
 
-    def _run_after(self, response):
+    def _run_after(self, response: BaseResponse) -> None:
         """Run callbacks registered with :meth:`morepath.Request.after`."""
         # if we don't have anything to run, don't even check status
         if not self._after:
@@ -323,7 +416,7 @@ class Request(BaseRequest):
         for after in self._after:
             after(response)
 
-    def clear_after(self):
+    def clear_after(self) -> None:
         self._after = []
 
 
@@ -332,5 +425,3 @@ class Response(BaseResponse):
 
     Extends :class:`webob.response.Response`.
     """
-
-    pass

--- a/morepath/run.py
+++ b/morepath/run.py
@@ -1,7 +1,19 @@
+from __future__ import annotations
+
 import sys
+from typing import TYPE_CHECKING, NoReturn
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser
+    from collections.abc import Callable
+    from wsgiref.simple_server import WSGIServer
+
+    from .types import WSGIApplication
 
 
-def make_parser(prog, default_host, default_port):
+def make_parser(
+    prog: str | None, default_host: str, default_port: int
+) -> ArgumentParser:
     """Make a command-line parser with host and port arguments.
 
     :param prog: the name of the program
@@ -11,7 +23,7 @@ def make_parser(prog, default_host, default_port):
     """
     import argparse
 
-    def unsigned_short(s):
+    def unsigned_short(s: str) -> int:
         v = int(s)
         if not 0 <= v <= 65536:
             raise ValueError
@@ -33,13 +45,13 @@ def make_parser(prog, default_host, default_port):
 
 
 def run(
-    wsgi,
-    host="127.0.0.1",
-    port=5000,
-    prog=None,
-    ignore_cli=False,
-    callback=None,
-):
+    wsgi: WSGIApplication,
+    host: str = "127.0.0.1",
+    port: int = 5000,
+    prog: str | None = None,
+    ignore_cli: bool = False,
+    callback: Callable[[WSGIServer], object] | None = None,
+) -> NoReturn:
     """Uses wsgiref.simple_server to run an application for debugging purposes.
 
     By default, this function looks at the command line for arguments
@@ -95,7 +107,7 @@ def run(
         if ex.errno == errno.EADDRINUSE and not ignore_cli:
             hint = "\n  Use '--port PORT' to specify a different port.\n\n"
         parser.exit(
-            ex.errno,
+            1 if ex.errno is None else ex.errno,
             f"{parser.prog}: {ex}: {args.host}:{args.port}\n" + hint,
         )
 
@@ -104,7 +116,9 @@ def run(
 
     print(f"Running {wsgi}")
     print(
-        "Listening on http://{}:{}".format(
+        # FIXME: Do we want to try to coerce from bytes to str, if we get
+        #        bytes or a bytearray?
+        "Listening on http://{}:{}".format(  # type: ignore[str-bytes-safe]
             server.server_address[0], server.server_port
         )
     )

--- a/morepath/settings.py
+++ b/morepath/settings.py
@@ -3,6 +3,13 @@
 See :class:`morepath.directive.SettingRegistry`
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 
 class SettingRegistry:
     """Registry of settings.
@@ -17,7 +24,9 @@ class SettingRegistry:
     :attr:`morepath.App.settings`.
     """
 
-    def register_setting(self, section_name, setting_name, func):
+    def register_setting(
+        self, section_name: str, setting_name: str, func: Callable[[], object]
+    ) -> None:
         """Register a setting.
 
         :param section_name: name of section to register in
@@ -31,8 +40,19 @@ class SettingRegistry:
             setattr(self, section_name, section)
         setattr(section, setting_name, func())
 
+    if TYPE_CHECKING:
+        # NOTE: Let type checkers know about dynamic attributes
+        def __getattr__(self, name: str) -> SettingSection:
+            raise NotImplementedError
+
 
 class SettingSection:
     """A setting section that contains setting."""
 
-    pass
+    if TYPE_CHECKING:
+        # NOTE: Let type checkers know about dynamic attributes
+        def __getattr__(self, name: str) -> Any:
+            raise NotImplementedError
+
+        def __setattr__(self, name: str, value: Any) -> None:
+            pass

--- a/morepath/template.py
+++ b/morepath/template.py
@@ -3,11 +3,21 @@
 See :class:`morepath.directive.TemplateEngineRegistry`
 """
 
+from __future__ import annotations
+
 import os
+from typing import TYPE_CHECKING, Any
 
 from .error import ConfigError, TopologicalSortError
 from .settings import SettingRegistry
 from .toposort import Info, toposorted
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from dectate.config import Configurable
+
+    from .types import GetRender, GetStrPath, Render, StrPath
 
 
 class TemplateEngineRegistry:
@@ -24,16 +34,23 @@ class TemplateEngineRegistry:
 
     factory_arguments = {"setting_registry": SettingRegistry}
 
-    def __init__(self, setting_registry):
+    def __init__(self, setting_registry: SettingRegistry) -> None:
         self._setting_registry = setting_registry
-        self._template_loaders = {}
-        self._template_renders = {}
-        self._template_directory_infos = []
-        self._template_configurable_to_keys = {}
+        self._template_loaders: dict[str, Any] = {}
+        self._template_renders: dict[str, GetRender] = {}
+        self._template_directory_infos: list[TemplateDirectoryInfo] = []
+        self._template_configurable_to_keys: dict[
+            Configurable, list[GetStrPath]
+        ] = {}
 
     def register_template_directory_info(
-        self, key, directory, before, after, configurable
-    ):
+        self,
+        key: GetStrPath,
+        directory: StrPath,
+        before: GetStrPath | None,
+        after: GetStrPath | None,
+        configurable: Configurable,
+    ) -> None:
         """Register a directory to look for templates.
 
         Used by the :meth:`morepath.App.template_directory` directive.
@@ -53,7 +70,7 @@ class TemplateEngineRegistry:
             key
         )
 
-    def register_template_render(self, extension, func):
+    def register_template_render(self, extension: str, func: GetRender) -> None:
         """Register way to get a view render function for a file extension.
 
         Used by the :meth:`morepath.App.template_render` directive. See
@@ -65,12 +82,16 @@ class TemplateEngineRegistry:
         """
         self._template_renders[extension] = func
 
-    def initialize_template_loader(self, extension, func):
+    def initialize_template_loader(
+        self,
+        extension: str,
+        func: Callable[[list[StrPath], SettingRegistry], Any],
+    ) -> None:
         """Initialize a template loader for an extension.
 
         Used by the :meth:`morepath.App.template_loader` directive.
 
-        :param extension: template extension like ``.p.t``
+        :param extension: template extension like ``.pt``
         :param func: function that given a list of template directories
           returns a load object that be used to load the template for use.
         """
@@ -78,7 +99,7 @@ class TemplateEngineRegistry:
             self.sorted_template_directories(), self._setting_registry
         )
 
-    def sorted_template_directories(self):
+    def sorted_template_directories(self) -> list[StrPath]:
         """Get sorted template directories.
 
         Use explicit ``before`` and ``after`` information but also
@@ -108,7 +129,11 @@ class TemplateEngineRegistry:
                 "application inheritance."
             )
 
-    def get_template_render(self, name, original_render):
+    def get_template_render(
+        self,
+        name: str,
+        original_render: Render,
+    ) -> Render:
         """Get a template render function.
 
         :param name: filename of the template (with extension, without path),
@@ -132,10 +157,17 @@ class TemplateEngineRegistry:
         return get_render(loader, name, original_render)
 
 
-class TemplateDirectoryInfo(Info):
+class TemplateDirectoryInfo(Info["GetStrPath"]):
     """Used by :class:`TemplateEngineRegistry` internally."""
 
-    def __init__(self, key, directory, before, after, configurable):
+    def __init__(
+        self,
+        key: GetStrPath,
+        directory: StrPath,
+        before: GetStrPath | None,
+        after: GetStrPath | None,
+        configurable: Configurable,
+    ) -> None:
         super().__init__(key, before, after)
         self.directory = directory
         self.configurable = configurable

--- a/morepath/tests/capturelog.py
+++ b/morepath/tests/capturelog.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 
@@ -18,33 +20,33 @@ class CaptureLog(logging.Handler):
       higher than this level are captured.
     """
 
-    def __init__(self, logger_name, level=logging.WARNING):
+    def __init__(self, logger_name: str, level: int = logging.WARNING):
         super().__init__(level)
         self.logger_name = logger_name
         self.level = level
-        self.records = []
+        self.records: list[logging.LogRecord] = []
         """Logging records captured.
         """
 
     @property
-    def record_tuples(self):
+    def record_tuples(self) -> list[tuple[str, int, str]]:
         """Returns list of log entries in tuple form.
 
         The format of the tuple is ``(logger_name, log_level, message)``
         """
         return [(r.name, r.levelno, r.getMessage()) for r in self.records]
 
-    def emit(self, record):
+    def emit(self, record: logging.LogRecord) -> None:
         self.records.append(record)
 
-    def __enter__(self):
+    def __enter__(self) -> CaptureLog:
         self.records = []
         logger = logging.getLogger(self.logger_name)
         logger.addHandler(self)
         logger.setLevel(self.level)
         return self
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, type: object, value: object, traceback: object) -> None:
         logger = logging.getLogger(self.logger_name)
         logger.removeHandler(self)
         logger.setLevel(logging.NOTSET)

--- a/morepath/tests/conftest.py
+++ b/morepath/tests/conftest.py
@@ -1,8 +1,15 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, NoReturn
+
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 @pytest.fixture
-def mockserver(monkeypatch):
+def mockserver(monkeypatch: pytest.MonkeyPatch) -> MockServer:
     """Make the server in wsgiref receive Ctrl-C as soon as it starts serving.
 
     The fixture object provides these methods:
@@ -13,7 +20,7 @@ def mockserver(monkeypatch):
     import sys
     from wsgiref.simple_server import WSGIServer
 
-    def mock_serve_forever(self):
+    def mock_serve_forever(self: WSGIServer) -> NoReturn:
         raise KeyboardInterrupt
 
     monkeypatch.setattr(WSGIServer, "serve_forever", mock_serve_forever)
@@ -23,14 +30,14 @@ def mockserver(monkeypatch):
 
 
 class MockServer:
-    def __init__(self, argv):
+    def __init__(self, argv: list[str]) -> None:
         self.argv = argv
 
-    def set_argv(self, argv):
+    def set_argv(self, argv: Iterable[str]) -> None:
         """Set the command-line arguments seen by morepath.run."""
         self.argv.extend(argv)
 
-    def run(self, *args, **kw):
+    def run(self, *args: Any, **kw: Any) -> str | int | None:
         """Wrapper around morepath.run to catch SystemExit.
 
         :return: the exit code."""

--- a/morepath/tests/fixtures/config/settings.py
+++ b/morepath/tests/fixtures/config/settings.py
@@ -4,9 +4,12 @@ It contains also a helper function to create a JSON config file
 from this dictionary.
 """
 
-import json
+from __future__ import annotations
 
-settings = {
+import json
+from typing import Any
+
+settings: dict[str, Any] = {
     "chameleon": {"debug": True},
     "jinja2": {
         "auto_reload": False,
@@ -26,7 +29,7 @@ settings = {
 }
 
 
-def create_json_config():
+def create_json_config() -> None:
     stream = open("settings.json", "w")
     json.dump(
         settings, stream, sort_keys=True, indent=4, separators=(",", ": ")

--- a/morepath/tests/test_autosetup.py
+++ b/morepath/tests/test_autosetup.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from collections import namedtuple
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import pytest
 from base.m import App
@@ -13,8 +16,14 @@ from morepath.autosetup import (
     morepath_packages,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
-def test_import():
+
+_T = TypeVar("_T")
+
+
+def test_import() -> None:
     import base
     import entrypoint
 
@@ -30,9 +39,9 @@ def test_import():
     assert {no_mp, nomp, no_mp_sub}.isdisjoint(found)
 
 
-def test_load_distribution():
+def test_load_distribution() -> None:
 
-    Distribution = namedtuple("Distribution", ["name"])
+    Distribution = cast("Any", namedtuple("Distribution", ["name"]))
 
     assert import_package(Distribution("base")).m.App is App
 
@@ -40,26 +49,27 @@ def test_load_distribution():
         import_package(Distribution("inexistant-package"))
 
 
-def invoke(callable):
+def invoke(callable: Callable[[], _T]) -> _T:
     "Add one frame to stack, no other purpose."
     return callable()
 
 
-def test_caller_module():
+def test_caller_module() -> None:
     import sys
 
     assert caller_module(1) == sys.modules[__name__]
     assert invoke(caller_module) == sys.modules[__name__]
 
 
-def test_caller_package():
+def test_caller_package() -> None:
     import sys
 
+    assert __package__ is not None
     assert caller_package(1) == sys.modules[__package__]
     assert invoke(caller_package) == sys.modules[__package__]
 
 
-def test_autoscan(monkeypatch):
+def test_autoscan(monkeypatch: pytest.MonkeyPatch) -> None:
     import sys
 
     for k in "base.m", "entrypoint.app", "under_score.m":
@@ -72,7 +82,7 @@ def test_autoscan(monkeypatch):
     assert "under_score.m" in sys.modules
 
 
-def test_circular_dependency():
+def test_circular_dependency() -> None:
     m = DependencyMap()
     m._d = {
         "parent": {"grandparent"},
@@ -85,7 +95,7 @@ def test_circular_dependency():
         assert m.depends(node, "grandparent")
 
 
-def test_depends_visited_parameter():
+def test_depends_visited_parameter() -> None:
     # Test that the visited parameter is properly initialized when not provided
     m = DependencyMap()
     m._d = {

--- a/morepath/tests/test_capturelog.py
+++ b/morepath/tests/test_capturelog.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import logging
 
 from .capturelog import CaptureLog
 
 
-def test_basic():
+def test_basic() -> None:
     logger = logging.getLogger("experiment")
 
     with CaptureLog("experiment") as captured:
@@ -15,7 +17,7 @@ def test_basic():
     assert captured.records[0].getMessage() == "Hello"
 
 
-def test_record_tuples():
+def test_record_tuples() -> None:
     logger = logging.getLogger("experiment")
 
     with CaptureLog("experiment") as captured:
@@ -25,7 +27,7 @@ def test_record_tuples():
     assert captured.record_tuples[0] == ("experiment", logging.WARNING, "Hello")
 
 
-def test_different_name():
+def test_different_name() -> None:
     logger = logging.getLogger("experiment")
 
     with CaptureLog("different") as captured:
@@ -34,7 +36,7 @@ def test_different_name():
     assert len(captured.records) == 0
 
 
-def test_name_prefix():
+def test_name_prefix() -> None:
     logger = logging.getLogger("prefix.experiment")
 
     with CaptureLog("prefix") as captured:
@@ -43,7 +45,7 @@ def test_name_prefix():
     assert len(captured.records) == 1
 
 
-def test_default_level():
+def test_default_level() -> None:
     logger = logging.getLogger("experiment")
 
     with CaptureLog("experiment") as captured:
@@ -54,7 +56,7 @@ def test_default_level():
     assert captured.records[0].msg == "Captured"
 
 
-def test_change_level():
+def test_change_level() -> None:
     logger = logging.getLogger("experiment")
 
     with CaptureLog("experiment", logging.DEBUG) as captured:

--- a/morepath/tests/test_cleanup.py
+++ b/morepath/tests/test_cleanup.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import dectate
 import morepath
 
 
-def test_cleanup():
+def test_cleanup() -> None:
     class App(morepath.App):
         pass
 

--- a/morepath/tests/test_code_info.py
+++ b/morepath/tests/test_code_info.py
@@ -1,17 +1,19 @@
+from __future__ import annotations
+
 import morepath
 
 
-def test_code_info():
+def test_code_info() -> None:
     class App(morepath.App):
         pass
 
     @App.path(path="")
     class Model:
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: object) -> str:
         return "View"
 
     App.commit()
@@ -25,7 +27,7 @@ def test_code_info():
     assert r.view_code_info.sourceline == "@App.view(model=Model)"
 
 
-def test_code_info_no_path():
+def test_code_info_no_path() -> None:
     class App(morepath.App):
         pass
 

--- a/morepath/tests/test_config_logging.py
+++ b/morepath/tests/test_config_logging.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 from webtest import TestApp as Client
@@ -8,7 +10,7 @@ from .capturelog import CaptureLog
 from .fixtures import basic
 
 
-def test_config_logging_implicit_commit():
+def test_config_logging_implicit_commit() -> None:
     class App(morepath.App):
         pass
 
@@ -17,7 +19,7 @@ def test_config_logging_implicit_commit():
         pass
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View"
 
     with CaptureLog("morepath.directive.path", logging.DEBUG) as captured:
@@ -42,7 +44,7 @@ def test_config_logging_implicit_commit():
         assert messages == []
 
 
-def test_config_logging_explicit_commit():
+def test_config_logging_explicit_commit() -> None:
     # Manually commit the app:
     with CaptureLog("morepath.directive.path", logging.DEBUG) as captured:
         assert basic.app.commit() == {basic.app}

--- a/morepath/tests/test_converter.py
+++ b/morepath/tests/test_converter.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from dectate import DirectiveError
@@ -10,7 +12,7 @@ from ..converter import (
 )
 
 
-def test_converter_registry():
+def test_converter_registry() -> None:
     r = ConverterRegistry()
 
     c = Converter(int, str)
@@ -22,11 +24,11 @@ def test_converter_registry():
         r.get_converter(str)
 
 
-def test_converter_registry_inheritance():
+def test_converter_registry_inheritance() -> None:
     r = ConverterRegistry()
 
     class Lifeform:
-        def __init__(self, name):
+        def __init__(self, name: str) -> None:
             self.name = name
 
     class Animal(Lifeform):
@@ -40,13 +42,13 @@ def test_converter_registry_inheritance():
         "elephant": elephant,
     }
 
-    def lifeform_decode(s):
+    def lifeform_decode(s: str) -> Lifeform:
         try:
             return lifeforms[s]
         except KeyError:
             raise ValueError
 
-    def lifeform_encode(lifeform):
+    def lifeform_encode(lifeform: Lifeform) -> str:
         return lifeform.name
 
     c = Converter(lifeform_decode, lifeform_encode)
@@ -62,17 +64,17 @@ def test_converter_registry_inheritance():
     assert r.get_converter(Lifeform).encode(seaweed) == ["seaweed"]
 
 
-def test_converter_equality():
-    def decode():
+def test_converter_equality() -> None:
+    def decode(x: str) -> object:
         pass
 
-    def encode():
-        pass
+    def encode(x: object) -> str:
+        return "x"
 
-    def other_encode():
-        pass
+    def other_encode(x: object) -> str:
+        return "y"
 
-    def other_decode():
+    def other_decode(x: str) -> object:
         pass
 
     one = Converter(decode, encode)

--- a/morepath/tests/test_defer_links.py
+++ b/morepath/tests/test_defer_links.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 import pytest
 from webtest import TestApp as Client
 
@@ -5,7 +9,7 @@ import morepath
 from morepath.error import ConflictError, LinkError
 
 
-def test_defer_links():
+def test_defer_links() -> None:
     class Root(morepath.App):
         pass
 
@@ -17,11 +21,13 @@ def test_defer_links():
         pass
 
     @Root.view(model=RootModel)
-    def root_model_default(self, request):
+    def root_model_default(self: RootModel, request: morepath.Request) -> str:
         return request.link(SubModel())
 
     @Root.view(model=RootModel, name="class_link")
-    def root_model_class_link(self, request):
+    def root_model_class_link(
+        self: RootModel, request: morepath.Request
+    ) -> str:
         return request.class_link(SubModel)
 
     @Sub.path(path="")
@@ -29,11 +35,11 @@ def test_defer_links():
         pass
 
     @Root.mount(app=Sub, path="sub")
-    def mount_sub():
+    def mount_sub() -> Sub:
         return Sub()
 
     @Root.defer_links(model=SubModel)
-    def defer_links_sub_model(app, obj):
+    def defer_links_sub_model(app: Root, obj: SubModel) -> morepath.App | None:
         return app.child(Sub())
 
     c = Client(Root())
@@ -45,7 +51,7 @@ def test_defer_links():
         c.get("/class_link")
 
 
-def test_defer_view():
+def test_defer_view() -> None:
     class Root(morepath.App):
         pass
 
@@ -57,7 +63,7 @@ def test_defer_view():
         pass
 
     @Root.json(model=RootModel)
-    def root_model_default(self, request):
+    def root_model_default(self: RootModel, request: morepath.Request) -> Any:
         return request.view(SubModel())
 
     @Sub.path(path="")
@@ -65,15 +71,17 @@ def test_defer_view():
         pass
 
     @Sub.json(model=SubModel)
-    def submodel_default(self, request):
+    def submodel_default(
+        self: SubModel, request: morepath.Request
+    ) -> dict[str, Any]:
         return {"hello": "world"}
 
     @Root.mount(app=Sub, path="sub")
-    def mount_sub():
+    def mount_sub() -> Sub:
         return Sub()
 
     @Root.defer_links(model=SubModel)
-    def defer_links_sub_model(app, obj):
+    def defer_links_sub_model(app: Root, obj: SubModel) -> morepath.App | None:
         return app.child(Sub())
 
     c = Client(Root())
@@ -82,7 +90,7 @@ def test_defer_view():
     assert response.json == {"hello": "world"}
 
 
-def test_defer_view_predicates():
+def test_defer_view_predicates() -> None:
     class Root(morepath.App):
         pass
 
@@ -94,7 +102,7 @@ def test_defer_view_predicates():
         pass
 
     @Root.json(model=RootModel)
-    def root_model_default(self, request):
+    def root_model_default(self: RootModel, request: morepath.Request) -> Any:
         return request.view(SubModel(), name="edit")
 
     @Sub.path(path="")
@@ -102,15 +110,15 @@ def test_defer_view_predicates():
         pass
 
     @Sub.json(model=SubModel, name="edit")
-    def submodel_edit(self, request):
+    def submodel_edit(self: Sub, request: SubModel) -> dict[str, Any]:
         return {"hello": "world"}
 
     @Root.mount(app=Sub, path="sub")
-    def mount_sub():
+    def mount_sub() -> Sub:
         return Sub()
 
     @Root.defer_links(model=SubModel)
-    def defer_links_sub_model(app, obj):
+    def defer_links_sub_model(app: Root, obj: SubModel) -> morepath.App | None:
         return app.child(Sub())
 
     c = Client(Root())
@@ -119,7 +127,7 @@ def test_defer_view_predicates():
     assert response.json == {"hello": "world"}
 
 
-def test_defer_view_missing_view():
+def test_defer_view_missing_view() -> None:
     class Root(morepath.App):
         pass
 
@@ -131,7 +139,9 @@ def test_defer_view_missing_view():
         pass
 
     @Root.json(model=RootModel)
-    def root_model_default(self, request):
+    def root_model_default(
+        self: RootModel, request: morepath.Request
+    ) -> dict[str, Any]:
         return {"not_found": request.view(SubModel(), name="unknown")}
 
     @Sub.path(path="")
@@ -139,15 +149,15 @@ def test_defer_view_missing_view():
         pass
 
     @Sub.json(model=SubModel, name="edit")
-    def submodel_edit(self, request):
+    def submodel_edit(self: Sub, request: morepath.Request) -> dict[str, Any]:
         return {"hello": "world"}
 
     @Root.mount(app=Sub, path="sub")
-    def mount_sub():
+    def mount_sub() -> Sub:
         return Sub()
 
     @Root.defer_links(model=SubModel)
-    def defer_links_sub_model(app, obj):
+    def defer_links_sub_model(app: Root, obj: SubModel) -> morepath.App | None:
         return app.child(Sub())
 
     c = Client(Root())
@@ -156,40 +166,39 @@ def test_defer_view_missing_view():
     assert response.json == {"not_found": None}
 
 
-def test_defer_links_mount_parameters():
+def test_defer_links_mount_parameters() -> None:
     class root(morepath.App):
         pass
 
     class sub(morepath.App):
-        pass
 
-        def __init__(self, name):
+        def __init__(self, name: str) -> None:
             self.name = name
 
     @root.path(path="")
     class RootModel:
         pass
 
-    @root.view(model=RootModel)
-    def root_model_default(self, request):
-        return request.link(SubModel("foo"))
-
     class SubModel:
-        def __init__(self, name):
+        def __init__(self, name: str) -> None:
             self.name = name
 
+    @root.view(model=RootModel)
+    def root_model_default(self: RootModel, request: morepath.Request) -> str:
+        return request.link(SubModel("foo"))
+
     @sub.path(path="", model=SubModel)
-    def get_sub_model(request):
+    def get_sub_model(request: morepath.Request[sub]) -> SubModel:
         return SubModel(request.app.name)
 
     @root.mount(
         app=sub, path="{mount_name}", variables=lambda a: {"mount_name": a.name}
     )
-    def mount_sub(mount_name):
+    def mount_sub(mount_name: str) -> sub:
         return sub(name=mount_name)
 
     @root.defer_links(model=SubModel)
-    def defer_links_sub_model(app, obj):
+    def defer_links_sub_model(app: root, obj: SubModel) -> morepath.App | None:
         return app.child(sub(name=obj.name))
 
     c = Client(root())
@@ -198,7 +207,7 @@ def test_defer_links_mount_parameters():
     assert response.body == b"http://localhost/foo"
 
 
-def test_defer_link_acquisition():
+def test_defer_link_acquisition() -> None:
     class root(morepath.App):
         pass
 
@@ -207,11 +216,11 @@ def test_defer_link_acquisition():
 
     @root.path(path="model/{id}")
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @root.view(model=Model)
-    def model_default(self, request):
+    def model_default(self: Model, request: morepath.Request) -> str:
         return "Hello"
 
     @sub.path(path="")
@@ -219,15 +228,15 @@ def test_defer_link_acquisition():
         pass
 
     @sub.view(model=SubModel)
-    def sub_model_default(self, request):
+    def sub_model_default(self: SubModel, request: morepath.Request) -> str:
         return request.link(Model("foo"))
 
     @root.mount(app=sub, path="sub")
-    def mount_sub(obj, app):
+    def mount_sub(obj: object, app: root) -> morepath.App | None:
         return app.child(sub())
 
     @sub.defer_links(model=Model)
-    def get_parent(app, obj):
+    def get_parent(app: sub, obj: object) -> morepath.App | None:
         return app.parent
 
     c = Client(root())
@@ -236,7 +245,7 @@ def test_defer_link_acquisition():
     assert response.body == b"http://localhost/model/foo"
 
 
-def test_defer_view_acquisition():
+def test_defer_view_acquisition() -> None:
     class root(morepath.App):
         pass
 
@@ -245,11 +254,11 @@ def test_defer_view_acquisition():
 
     @root.path(path="model/{id}")
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @root.json(model=Model)
-    def model_default(self, request):
+    def model_default(self: Model, request: morepath.Request) -> dict[str, Any]:
         return {"Hello": "World"}
 
     @sub.path(path="")
@@ -257,15 +266,15 @@ def test_defer_view_acquisition():
         pass
 
     @sub.json(model=SubModel)
-    def sub_model_default(self, request):
+    def sub_model_default(self: SubModel, request: morepath.Request) -> Any:
         return request.view(Model("foo"))
 
     @root.mount(app=sub, path="sub")
-    def mount_sub(obj, app):
+    def mount_sub(obj: object, app: sub) -> morepath.App | None:
         return app.child(sub())
 
     @sub.defer_links(model=Model)
-    def get_parent(app, obj):
+    def get_parent(app: sub, obj: object) -> morepath.App | None:
         return app.parent
 
     c = Client(root())
@@ -274,7 +283,7 @@ def test_defer_view_acquisition():
     assert response.json == {"Hello": "World"}
 
 
-def test_defer_link_acquisition_blocking():
+def test_defer_link_acquisition_blocking() -> None:
     class root(morepath.App):
         pass
 
@@ -283,11 +292,11 @@ def test_defer_link_acquisition_blocking():
 
     @root.path(path="model/{id}")
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @root.view(model=Model)
-    def model_default(self, request):
+    def model_default(self: Model, request: morepath.Request) -> str:
         return "Hello"
 
     @sub.path(path="")
@@ -295,14 +304,14 @@ def test_defer_link_acquisition_blocking():
         pass
 
     @sub.view(model=SubModel)
-    def sub_model_default(self, request):
+    def sub_model_default(self: SubModel, request: morepath.Request) -> str:
         try:
             return request.link(Model("foo"))
         except LinkError:
             return "link error"
 
     @root.mount(app=sub, path="sub")
-    def mount_sub():
+    def mount_sub() -> sub:
         return sub()
 
     # no defer_links_to_parent
@@ -313,7 +322,7 @@ def test_defer_link_acquisition_blocking():
     assert response.body == b"link error"
 
 
-def test_defer_view_acquisition_blocking():
+def test_defer_view_acquisition_blocking() -> None:
     class root(morepath.App):
         pass
 
@@ -322,11 +331,11 @@ def test_defer_view_acquisition_blocking():
 
     @root.path(path="model/{id}")
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @root.json(model=Model)
-    def model_default(self, request):
+    def model_default(self: Model, request: morepath.Request) -> dict[str, Any]:
         return {"Hello": "World"}
 
     @sub.path(path="")
@@ -334,11 +343,11 @@ def test_defer_view_acquisition_blocking():
         pass
 
     @sub.json(model=SubModel)
-    def sub_model_default(self, request):
+    def sub_model_default(self: SubModel, request: morepath.Request) -> bool:
         return request.view(Model("foo")) is None
 
     @root.mount(app=sub, path="sub")
-    def mount_sub():
+    def mount_sub() -> sub:
         return sub()
 
     # no defer_links_to_parent
@@ -349,7 +358,7 @@ def test_defer_view_acquisition_blocking():
     assert response.json is True
 
 
-def test_defer_link_should_not_cause_web_views_to_exist():
+def test_defer_link_should_not_cause_web_views_to_exist() -> None:
     class root(morepath.App):
         pass
 
@@ -361,11 +370,11 @@ def test_defer_link_should_not_cause_web_views_to_exist():
         pass
 
     @root.view(model=Model)
-    def model_default(self, request):
+    def model_default(self: Model, request: morepath.Request) -> str:
         return "Hello"
 
     @root.view(model=Model, name="extra")
-    def model_extra(self, request):
+    def model_extra(self: Model, request: morepath.Request) -> str:
         return "Extra"
 
     # note inheritance from model. we still don't
@@ -375,15 +384,15 @@ def test_defer_link_should_not_cause_web_views_to_exist():
         pass
 
     @sub.view(model=SubModel)
-    def sub_model_default(self, request):
+    def sub_model_default(self: SubModel, request: morepath.Request) -> str:
         return request.link(Model())
 
     @root.mount(app=sub, path="sub")
-    def mount_sub():
+    def mount_sub() -> sub:
         return sub()
 
     @sub.defer_links(model=Model)
-    def get_parent(app, obj):
+    def get_parent(app: sub, obj: Model) -> morepath.App | None:
         return app.parent
 
     c = Client(root())
@@ -394,7 +403,7 @@ def test_defer_link_should_not_cause_web_views_to_exist():
     c.get("/sub/+extra", status=404)
 
 
-def test_defer_link_to_parent_from_root():
+def test_defer_link_to_parent_from_root() -> None:
     class root(morepath.App):
         pass
 
@@ -409,11 +418,11 @@ def test_defer_link_to_parent_from_root():
         pass
 
     @root.view(model=Model)
-    def model_default(self, request):
+    def model_default(self: Model, request: morepath.Request) -> str:
         return request.link(OtherModel())
 
     @root.defer_links(model=OtherModel)
-    def get_parent(app, obj):
+    def get_parent(app: root, obj: OtherModel) -> morepath.App | None:
         return app.parent
 
     c = Client(root())
@@ -422,7 +431,7 @@ def test_defer_link_to_parent_from_root():
         c.get("/")
 
 
-def test_special_link_overrides_deferred_link():
+def test_special_link_overrides_deferred_link() -> None:
     class root(morepath.App):
         pass
 
@@ -436,7 +445,7 @@ def test_special_link_overrides_deferred_link():
         pass
 
     @root.mount(app=alpha, path="alpha")
-    def mount_alpha():
+    def mount_alpha() -> alpha:
         return alpha()
 
     @root.path(path="")
@@ -444,23 +453,23 @@ def test_special_link_overrides_deferred_link():
         pass
 
     @root.path(model=SpecialAlphaModel, path="roots_alpha")
-    def get_root_alpha():
+    def get_root_alpha() -> SpecialAlphaModel:
         return SpecialAlphaModel()
 
     @root.view(model=RootModel)
-    def root_model_default(self, request):
+    def root_model_default(self: RootModel, request: morepath.Request) -> str:
         return request.link(AlphaModel())
 
     @root.view(model=RootModel, name="special")
-    def root_model_special(self, request):
+    def root_model_special(self: RootModel, request: morepath.Request) -> str:
         return request.link(SpecialAlphaModel())
 
     @alpha.path(path="", model=AlphaModel)
-    def get_alpha():
+    def get_alpha() -> AlphaModel:
         return AlphaModel()
 
     @root.defer_links(model=AlphaModel)
-    def defer_links_alpha(app, obj):
+    def defer_links_alpha(app: root, obj: AlphaModel) -> morepath.App | None:
         return app.child(alpha())
 
     c = Client(root())
@@ -472,7 +481,7 @@ def test_special_link_overrides_deferred_link():
     assert response.body == b"http://localhost/roots_alpha"
 
 
-def test_deferred_deferred_link():
+def test_deferred_deferred_link() -> None:
     class root(morepath.App):
         pass
 
@@ -487,7 +496,7 @@ def test_deferred_deferred_link():
         pass
 
     @root.view(model=RootModel)
-    def root_model_default(self, request):
+    def root_model_default(self: RootModel, request: morepath.Request) -> str:
         return request.link(AlphaModel())
 
     @alpha.path(path="")
@@ -499,23 +508,23 @@ def test_deferred_deferred_link():
         pass
 
     @beta.view(model=BetaModel)
-    def beta_model_default(self, request):
+    def beta_model_default(self: BetaModel, request: morepath.Request) -> str:
         return request.link(AlphaModel())
 
     @root.mount(app=alpha, path="alpha")
-    def mount_alpha():
+    def mount_alpha() -> alpha:
         return alpha()
 
     @root.mount(app=beta, path="beta")
-    def mount_beta():
+    def mount_beta() -> beta:
         return beta()
 
     @beta.defer_links(model=AlphaModel)
-    def defer_links_parent(app, obj):
+    def defer_links_parent(app: beta, obj: AlphaModel) -> morepath.App | None:
         return app.parent
 
     @root.defer_links(model=AlphaModel)
-    def defer_links_alpha(app, obj):
+    def defer_links_alpha(app: root, obj: AlphaModel) -> morepath.App | None:
         return app.child(alpha())
 
     c = Client(root())
@@ -527,7 +536,7 @@ def test_deferred_deferred_link():
     assert response.body == b"http://localhost/alpha"
 
 
-def test_deferred_deferred_view():
+def test_deferred_deferred_view() -> None:
     class root(morepath.App):
         pass
 
@@ -542,7 +551,7 @@ def test_deferred_deferred_view():
         pass
 
     @root.json(model=RootModel)
-    def root_model_default(self, request):
+    def root_model_default(self: RootModel, request: morepath.Request) -> Any:
         return request.view(AlphaModel())
 
     @alpha.path(path="")
@@ -550,7 +559,9 @@ def test_deferred_deferred_view():
         pass
 
     @alpha.json(model=AlphaModel)
-    def alpha_model_default(self, request):
+    def alpha_model_default(
+        self: AlphaModel, request: morepath.Request
+    ) -> dict[str, Any]:
         return {"model": "alpha"}
 
     @beta.path(path="")
@@ -558,23 +569,23 @@ def test_deferred_deferred_view():
         pass
 
     @beta.json(model=BetaModel)
-    def beta_model_default(self, request):
+    def beta_model_default(self: BetaModel, request: morepath.Request) -> Any:
         return request.view(AlphaModel())
 
     @root.mount(app=alpha, path="alpha")
-    def mount_alpha():
+    def mount_alpha() -> alpha:
         return alpha()
 
     @root.mount(app=beta, path="beta")
-    def mount_beta():
+    def mount_beta() -> beta:
         return beta()
 
     @beta.defer_links(model=AlphaModel)
-    def defer_links_parent(app, obj):
+    def defer_links_parent(app: beta, obj: AlphaModel) -> morepath.App | None:
         return app.parent
 
     @root.defer_links(model=AlphaModel)
-    def defer_links_alpha(app, obj):
+    def defer_links_alpha(app: root, obj: AlphaModel) -> morepath.App | None:
         return app.child(alpha())
 
     c = Client(root())
@@ -586,7 +597,7 @@ def test_deferred_deferred_view():
     assert response.json == {"model": "alpha"}
 
 
-def test_deferred_view_has_app_of_defer():
+def test_deferred_view_has_app_of_defer() -> None:
     class root(morepath.App):
         pass
 
@@ -597,11 +608,11 @@ def test_deferred_view_has_app_of_defer():
         pass
 
     @root.mount(app=alpha, path="alpha")
-    def mount_alpha():
+    def mount_alpha() -> alpha:
         return alpha()
 
     @root.mount(app=beta, path="beta")
-    def mount_beta():
+    def mount_beta() -> beta:
         return beta()
 
     @root.path(path="")
@@ -613,7 +624,7 @@ def test_deferred_view_has_app_of_defer():
         pass
 
     @alpha.json(model=AlphaModel)
-    def alpha_model_default(self, request):
+    def alpha_model_default(self: AlphaModel, request: morepath.Request) -> str:
         if request.app.__class__ == alpha:
             return "correct"
         else:
@@ -624,11 +635,12 @@ def test_deferred_view_has_app_of_defer():
         pass
 
     @beta.json(model=BetaModel)
-    def beta_model_default(self, request):
+    def beta_model_default(self: BetaModel, request: morepath.Request) -> Any:
         return request.view(AlphaModel())
 
     @beta.defer_links(model=AlphaModel)
-    def defer_links_parent(app, obj):
+    def defer_links_parent(app: beta, obj: AlphaModel) -> morepath.App | None:
+        assert app.parent is not None
         return app.parent.child("alpha")
 
     c = Client(root())
@@ -637,7 +649,7 @@ def test_deferred_view_has_app_of_defer():
     assert response.json == "correct"
 
 
-def test_deferred_loop():
+def test_deferred_loop() -> None:
     class root(morepath.App):
         pass
 
@@ -653,20 +665,20 @@ def test_deferred_loop():
         pass
 
     @root.json(model=RootModel)
-    def root_model_default(self, request):
+    def root_model_default(self: RootModel, request: morepath.Request) -> str:
         return request.link(Model())
 
     @root.mount(app=alpha, path="alpha")
-    def mount_alpha():
+    def mount_alpha() -> alpha:
         return alpha()
 
     # setup a loop: defer to parent and back to child!
     @alpha.defer_links(model=Model)
-    def defer_links_parent(app, obj):
+    def defer_links_parent(app: alpha, obj: Model) -> morepath.App | None:
         return app.parent
 
     @root.defer_links(model=Model)
-    def defer_links_alpha(app, obj):
+    def defer_links_alpha(app: root, obj: Model) -> morepath.App | None:
         return app.child(alpha())
 
     c = Client(root())
@@ -678,7 +690,7 @@ def test_deferred_loop():
 
 
 @pytest.mark.skip(reason="Infinite loop (#479)")
-def test_deferred_loop_siblings():
+def test_deferred_loop_siblings() -> None:
     # https://github.com/morepath/morepath/issues/479
     class Root(morepath.App):
         pass
@@ -698,28 +710,28 @@ def test_deferred_loop_siblings():
         pass
 
     @Root.json(model=RootModel)
-    def root_model_default(self, request):
+    def root_model_default(self: RootModel, request: morepath.Request) -> str:
         return request.link(Model())
 
     @Root.defer_links(model=Model)
-    def defer_links_alpha(app, obj):
+    def defer_links_alpha(app: Root, obj: Model) -> morepath.App | None:
         return app.child(Alpha())
 
     @Root.mount(app=Alpha, path="alpha")
-    def mount_alpha():
+    def mount_alpha() -> Alpha:
         return Alpha()
 
     @Root.mount(app=Beta, path="beta")
-    def mount_beta():
+    def mount_beta() -> Beta:
         return Beta()
 
     # setup a loop: defer to sibling and back
     @Alpha.defer_links(model=Model)
-    def defer_links_to_beta(app, obj):
+    def defer_links_to_beta(app: Alpha, obj: Model) -> morepath.App | None:
         return app.sibling(Beta())
 
     @Beta.defer_links(model=Model)
-    def defer_links_to_alpha(app, obj):
+    def defer_links_to_alpha(app: Beta, obj: Model) -> morepath.App | None:
         return app.sibling(Alpha())
 
     c = Client(Root())
@@ -731,7 +743,7 @@ def test_deferred_loop_siblings():
 
 
 # see issue #342
-def test_defer_link_scenario():
+def test_defer_link_scenario() -> None:
     class App(morepath.App):
         pass
 
@@ -742,11 +754,11 @@ def test_defer_link_scenario():
         pass
 
     @App.mount(app=Child, path="child")
-    def mount_child():
+    def mount_child() -> Child:
         return Child()
 
     @App.defer_links(model=Document)
-    def defer_document(app, doc):
+    def defer_document(app: App, doc: Document) -> morepath.App | None:
         return app.child(Child())
 
     @App.path(path="")
@@ -754,7 +766,7 @@ def test_defer_link_scenario():
         pass
 
     @App.json(model=Root)
-    def root_view(self, request):
+    def root_view(self: Root, request: morepath.Request) -> dict[str, Any]:
         return {
             "link": request.link(Document()),
             "view": request.view(Document()),
@@ -763,15 +775,19 @@ def test_defer_link_scenario():
     # if this is commented out, the Child app's view for Document
     # will be used by root_view, which is surprising.
     @App.json(model=Document)
-    def app_document_default(self, request):
+    def app_document_default(
+        self: Document, request: morepath.Request
+    ) -> dict[str, Any]:
         return {"app": "App"}
 
     @Child.path("", model=Document)
-    def get_document():
+    def get_document() -> Document:
         return Document()
 
     @Child.json(model=Document)
-    def document_default(self, request):
+    def document_default(
+        self: Document, request: morepath.Request
+    ) -> dict[str, Any]:
         return {
             "app": "Child",
         }
@@ -794,7 +810,7 @@ def test_defer_link_scenario():
     }
 
 
-def test_defer_class_links_without_variables():
+def test_defer_class_links_without_variables() -> None:
     class Root(morepath.App):
         pass
 
@@ -806,7 +822,7 @@ def test_defer_class_links_without_variables():
         pass
 
     @Root.view(model=RootModel)
-    def root_model_default(self, request):
+    def root_model_default(self: RootModel, request: morepath.Request) -> str:
         return request.class_link(SubModel)
 
     @Sub.path(path="")
@@ -814,11 +830,13 @@ def test_defer_class_links_without_variables():
         pass
 
     @Root.mount(app=Sub, path="sub")
-    def mount_sub():
+    def mount_sub() -> Sub:
         return Sub()
 
     @Root.defer_class_links(model=SubModel, variables=lambda obj: {})
-    def defer_class_links_sub_model(app, model, variables):
+    def defer_class_links_sub_model(
+        app: Root, model: SubModel, variables: dict[str, Any]
+    ) -> morepath.App | None:
         return app.child(Sub())
 
     c = Client(Root())
@@ -827,7 +845,7 @@ def test_defer_class_links_without_variables():
     assert response.body == b"http://localhost/sub"
 
 
-def test_defer_class_links_with_variables():
+def test_defer_class_links_with_variables() -> None:
     class Root(morepath.App):
         pass
 
@@ -839,22 +857,24 @@ def test_defer_class_links_with_variables():
         pass
 
     @Root.view(model=RootModel)
-    def root_model_default(self, request):
+    def root_model_default(self: Root, request: morepath.Request) -> str:
         return request.class_link(SubModel, variables=dict(name="foo"))
 
     @Sub.path(path="{name}")
     class SubModel:
-        def __init__(self, name):
+        def __init__(self, name: str) -> None:
             self.name = name
 
     @Root.mount(app=Sub, path="sub")
-    def mount_sub():
+    def mount_sub() -> Sub:
         return Sub()
 
     @Root.defer_class_links(
         model=SubModel, variables=lambda obj: {"name": obj.name}
     )
-    def defer_class_links_sub_model(app, model, variables):
+    def defer_class_links_sub_model(
+        app: Root, model: SubModel, variables: dict[str, Any]
+    ) -> morepath.App | None:
         return app.child(Sub())
 
     c = Client(Root())
@@ -863,7 +883,7 @@ def test_defer_class_links_with_variables():
     assert response.body == b"http://localhost/sub/foo"
 
 
-def test_deferred_class_link_loop():
+def test_deferred_class_link_loop() -> None:
     class Root(morepath.App):
         pass
 
@@ -879,20 +899,24 @@ def test_deferred_class_link_loop():
         pass
 
     @Root.view(model=RootModel)
-    def root_model_default(self, request):
+    def root_model_default(self: RootModel, request: morepath.Request) -> str:
         return request.class_link(SubModel)
 
     @Root.mount(app=Alpha, path="alpha")
-    def mount_alpha():
+    def mount_alpha() -> Alpha:
         return Alpha()
 
     # setup a loop: defer to parent and back to child!
     @Alpha.defer_class_links(model=SubModel, variables=lambda obj: {})
-    def defer_class_links_parent(app, obj, variables):
+    def defer_class_links_parent(
+        app: Alpha, obj: SubModel, variables: dict[str, Any]
+    ) -> morepath.App | None:
         return app.parent
 
     @Root.defer_class_links(model=SubModel, variables=lambda obj: {})
-    def defer_class_links_alpha(app, obj, variables):
+    def defer_class_links_alpha(
+        app: Root, obj: SubModel, variables: dict[str, Any]
+    ) -> morepath.App | None:
         return app.child(Alpha())
 
     c = Client(Root())
@@ -903,7 +927,7 @@ def test_deferred_class_link_loop():
     assert "Circular" in str(ex.value)
 
 
-def test_link_uses_defer_class_links():
+def test_link_uses_defer_class_links() -> None:
     class Root(morepath.App):
         pass
 
@@ -914,23 +938,25 @@ def test_link_uses_defer_class_links():
     class RootModel:
         pass
 
-    @Root.view(model=RootModel)
-    def root_model_default(self, request):
-        return request.link(SubModel("foo"))
-
     @Sub.path(path="{name}")
     class SubModel:
-        def __init__(self, name):
+        def __init__(self, name: str) -> None:
             self.name = name
 
+    @Root.view(model=RootModel)
+    def root_model_default(self: RootModel, request: morepath.Request) -> str:
+        return request.link(SubModel("foo"))
+
     @Root.mount(app=Sub, path="sub")
-    def mount_sub():
+    def mount_sub() -> Sub:
         return Sub()
 
     @Root.defer_class_links(
         model=SubModel, variables=lambda obj: {"name": obj.name}
     )
-    def defer_class_links_sub_model(app, model, variables):
+    def defer_class_links_sub_model(
+        app: Root, model: SubModel, variables: dict[str, Any]
+    ) -> morepath.App | None:
         return app.child(Sub())
 
     c = Client(Root())
@@ -939,7 +965,7 @@ def test_link_uses_defer_class_links():
     assert response.body == b"http://localhost/sub/foo"
 
 
-def test_defer_links_and_defer_links_conflict():
+def test_defer_links_and_defer_links_conflict() -> None:
     class Root(morepath.App):
         pass
 
@@ -950,27 +976,29 @@ def test_defer_links_and_defer_links_conflict():
     class RootModel:
         pass
 
-    @Root.view(model=RootModel)
-    def root_model_default(self, request):
-        return request.link(SubModel("foo"))
-
     @Sub.path(path="{name}")
     class SubModel:
-        def __init__(self, name):
+        def __init__(self, name: str) -> None:
             self.name = name
 
+    @Root.view(model=RootModel)
+    def root_model_default(self: RootModel, request: morepath.Request) -> str:
+        return request.link(SubModel("foo"))
+
     @Root.mount(app=Sub, path="sub")
-    def mount_sub():
+    def mount_sub() -> Sub:
         return Sub()
 
     @Root.defer_links(model=SubModel)
-    def defer_links_sub_model(app, obj):
-        return app.chidl(Sub())
+    def defer_links_sub_model(app: Root, obj: SubModel) -> morepath.App | None:
+        return app.child(Sub())
 
     @Root.defer_class_links(
         model=SubModel, variables=lambda obj: {"name": obj.name}
     )
-    def defer_class_links_sub_model(app, model, variables):
+    def defer_class_links_sub_model(
+        app: Root, model: SubModel, variables: dict[str, Any]
+    ) -> morepath.App | None:
         return app.child(Sub())
 
     with pytest.raises(ConflictError):

--- a/morepath/tests/test_directive.py
+++ b/morepath/tests/test_directive.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 import pytest
 from webtest import TestApp as Client
 
@@ -19,8 +23,11 @@ from .fixtures import (
     noconverter,
 )
 
+if TYPE_CHECKING:
+    from webob import Response as BaseResponse
 
-def test_basic():
+
+def test_basic() -> None:
     c = Client(basic.app())
 
     response = c.get("/foo")
@@ -31,7 +38,7 @@ def test_basic():
     assert response.body == b"http://localhost/foo"
 
 
-def test_basic_json():
+def test_basic_json() -> None:
     c = Client(basic.app())
 
     response = c.get("/foo/json")
@@ -39,7 +46,7 @@ def test_basic_json():
     assert response.body == b'{"id":"foo"}'
 
 
-def test_basic_root():
+def test_basic_root() -> None:
     c = Client(basic.app())
 
     response = c.get("/")
@@ -52,7 +59,7 @@ def test_basic_root():
     assert response.body == b"http://localhost/"
 
 
-def test_nested():
+def test_nested() -> None:
     c = Client(nested.outer_app())
 
     response = c.get("/inner/foo")
@@ -63,7 +70,7 @@ def test_nested():
     assert response.body == b"http://localhost/inner/foo"
 
 
-def test_abbr():
+def test_abbr() -> None:
     c = Client(abbr.app())
 
     response = c.get("/foo")
@@ -73,7 +80,7 @@ def test_abbr():
     assert response.body == b"Edit view: foo"
 
 
-def test_scanned_static_method():
+def test_scanned_static_method() -> None:
     c = Client(method.app())
 
     response = c.get("/static")
@@ -83,51 +90,51 @@ def test_scanned_static_method():
     assert isinstance(root.static_method(), method.StaticMethod)
 
 
-def test_scanned_no_converter():
+def test_scanned_no_converter() -> None:
     with pytest.raises(DirectiveReportError):
         noconverter.app.commit()
 
 
-def test_scanned_conflict():
+def test_scanned_conflict() -> None:
     with pytest.raises(ConflictError):
         conflict.app.commit()
 
 
-def test_basic_scenario():
+def test_basic_scenario() -> None:
     class app(morepath.App):
         pass
 
     @app.path(path="")
     class Root:
-        def __init__(self):
+        def __init__(self) -> None:
             self.value = "ROOT"
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @app.path(model=Model, path="{id}")
-    def get_model(id):
+    def get_model(id: str) -> Model:
         return Model(id)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "The view for model: %s" % self.id
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     @app.view(model=Model, name="json", render=morepath.render_json)
-    def json(self, request):
+    def json(self: Model, request: morepath.Request) -> dict[str, Any]:
         return {"id": self.id}
 
     @app.view(model=Root)
-    def root_default(self, request):
+    def root_default(self: Root, request: morepath.Request) -> str:
         return "The root: %s" % self.value
 
     @app.view(model=Root, name="link")
-    def root_link(self, request):
+    def root_link(self: Root, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -149,28 +156,28 @@ def test_basic_scenario():
     assert response.body == b"http://localhost/"
 
 
-def test_link_to_unknown_model():
+def test_link_to_unknown_model() -> None:
     class app(morepath.App):
         pass
 
     @app.path(path="")
     class Root:
-        def __init__(self):
+        def __init__(self) -> None:
             self.value = "ROOT"
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @app.view(model=Root)
-    def root_link(self, request):
+    def root_link(self: Root, request: morepath.Request) -> str:
         try:
             return request.link(Model("foo"))
         except LinkError:
             return "Link error"
 
     @app.view(model=Root, name="default")
-    def root_link_with_default(self, request):
+    def root_link_with_default(self: Root, request: morepath.Request) -> str:
         try:
             return request.link(Model("foo"), default="hey")
         except LinkError:
@@ -184,25 +191,25 @@ def test_link_to_unknown_model():
     assert response.body == b"Link Error"
 
 
-def test_link_to_none():
+def test_link_to_none() -> None:
     class app(morepath.App):
         pass
 
     @app.path(path="")
     class Root:
-        def __init__(self):
+        def __init__(self) -> None:
             self.value = "ROOT"
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @app.view(model=Root)
-    def root_link(self, request):
+    def root_link(self: Root, request: morepath.Request) -> str:
         return str(request.link(None) is None)
 
     @app.view(model=Root, name="default")
-    def root_link_with_default(self, request):
+    def root_link_with_default(self: Root, request: morepath.Request) -> str:
         return request.link(None, default="unknown")
 
     c = Client(app())
@@ -213,31 +220,31 @@ def test_link_to_none():
     assert response.body == b"unknown"
 
 
-def test_link_with_parameters():
+def test_link_with_parameters() -> None:
     class app(morepath.App):
         pass
 
     @app.path(path="")
     class Root:
-        def __init__(self):
+        def __init__(self) -> None:
             self.value = "ROOT"
 
     class Model:
-        def __init__(self, id, param):
+        def __init__(self, id: str, param: int) -> None:
             self.id = id
             self.param = param
 
     @app.path(model=Model, path="{id}")
-    def get_model(id, param=0):
+    def get_model(id: str, param: int = 0) -> Model:
         assert isinstance(param, int)
         return Model(id, param)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return f"The view for model: {self.id} {self.param}"
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -255,22 +262,22 @@ def test_link_with_parameters():
     assert response.body == b"http://localhost/foo?param=1"
 
 
-def test_root_link_with_parameters():
+def test_root_link_with_parameters() -> None:
     class app(morepath.App):
         pass
 
     @app.path(path="")
     class Root:
-        def __init__(self, param=0):
+        def __init__(self, param: int = 0) -> None:
             assert isinstance(param, int)
             self.param = param
 
     @app.view(model=Root)
-    def default(self, request):
+    def default(self: Root, request: morepath.Request) -> str:
         return "The view for root: %s" % self.param
 
     @app.view(model=Root, name="link")
-    def link(self, request):
+    def link(self: Root, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -288,7 +295,7 @@ def test_root_link_with_parameters():
     assert response.body == b"http://localhost/?param=1"
 
 
-def test_link_with_prefix():
+def test_link_with_prefix() -> None:
     class app(morepath.App):
         pass
 
@@ -297,11 +304,11 @@ def test_link_with_prefix():
         pass
 
     @app.view(model=Root, name="link")
-    def link(self, request):
+    def link(self: Root, request: morepath.Request) -> str:
         return request.link(self)
 
     @app.link_prefix()
-    def link_prefix(request):
+    def link_prefix(request: morepath.Request) -> str:
         return request.headers["TESTPREFIX"]
 
     c = Client(app())
@@ -315,7 +322,7 @@ def test_link_with_prefix():
     assert response.body == b"http://testhost/"
 
 
-def test_link_with_prefix_app_arg():
+def test_link_with_prefix_app_arg() -> None:
     class App(morepath.App):
         pass
 
@@ -324,11 +331,11 @@ def test_link_with_prefix_app_arg():
         pass
 
     @App.view(model=Root, name="link")
-    def link(self, request):
+    def link(self: Root, request: morepath.Request) -> str:
         return request.link(self)
 
     @App.link_prefix()
-    def link_prefix(app, request):
+    def link_prefix(app: App, request: morepath.Request) -> str:
         assert isinstance(app, App)
         return request.headers["TESTPREFIX"]
 
@@ -343,7 +350,7 @@ def test_link_with_prefix_app_arg():
     assert response.body == b"http://testhost/"
 
 
-def test_link_prefix_cache():
+def test_link_prefix_cache() -> None:
     class app(morepath.App):
         pass
 
@@ -352,17 +359,17 @@ def test_link_prefix_cache():
         pass
 
     @app.view(model=Root, name="link")
-    def link(self, request):
+    def link(self: Root, request: morepath.Request) -> str:
         request.link(self)  # make an extra call before returning
         return request.link(self)
 
     @app.link_prefix()
-    def link_prefix(request):
+    def link_prefix(request: morepath.Request) -> str:
         if not hasattr(request, "callnumber"):
-            request.callnumber = 1
+            request.callnumber = 1  # type: ignore[attr-defined]
         else:
-            request.callnumber += 1
-        return str(request.callnumber)
+            request.callnumber += 1  # pyright: ignore
+        return str(request.callnumber)  # type: ignore[attr-defined]
 
     c = Client(app())
 
@@ -370,7 +377,7 @@ def test_link_prefix_cache():
     assert response.body == b"1/"
 
 
-def test_link_with_invalid_prefix():
+def test_link_with_invalid_prefix() -> None:
     class app(morepath.App):
         pass
 
@@ -379,11 +386,11 @@ def test_link_with_invalid_prefix():
         pass
 
     @app.view(model=Root, name="link")
-    def link(self, request):
+    def link(self: Root, request: morepath.Request) -> str:
         return request.link(self)
 
     @app.link_prefix()
-    def link_prefix(request):
+    def link_prefix(request: morepath.Request) -> None:
         return None
 
     c = Client(app())
@@ -392,7 +399,7 @@ def test_link_with_invalid_prefix():
         c.get("/link")
 
 
-def test_external_link_prefix():
+def test_external_link_prefix() -> None:
     class App(morepath.App):
         pass
 
@@ -406,23 +413,25 @@ def test_external_link_prefix():
         pass
 
     @App.path(model=InternalDoc, path="")
-    def internal_path(request):
+    def internal_path(request: morepath.Request) -> InternalDoc:
         return InternalDoc()
 
     @ExternalApp.path(model=ExternalDoc, path="external")
-    def external_path(request):
+    def external_path(request: morepath.Request) -> ExternalDoc:
         return ExternalDoc()
 
     @App.defer_links(model=ExternalDoc)
-    def defer_external_links(app, obj):
+    def defer_external_links(app: App, obj: ExternalDoc) -> ExternalApp:
         return ExternalApp()
 
     @ExternalApp.link_prefix()
-    def prefix_external_link(request):
+    def prefix_external_link(request: morepath.Request) -> str:
         return "example.org"
 
     @App.json(model=InternalDoc)
-    def main_view(self, request):
+    def main_view(
+        self: InternalDoc, request: morepath.Request
+    ) -> dict[str, Any]:
         return {
             "internal_link": request.link(InternalDoc()),
             "external_link_def": request.link(ExternalDoc()),
@@ -438,7 +447,7 @@ def test_external_link_prefix():
     }
 
 
-def test_implicit_variables():
+def test_implicit_variables() -> None:
     class app(morepath.App):
         pass
 
@@ -447,19 +456,19 @@ def test_implicit_variables():
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @app.path(model=Model, path="{id}")
-    def get_model(id):
+    def get_model(id: str) -> Model:
         return Model(id)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "The view for model: %s" % self.id
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -468,7 +477,7 @@ def test_implicit_variables():
     assert response.body == b"http://localhost/foo"
 
 
-def test_implicit_parameters():
+def test_implicit_parameters() -> None:
     class app(morepath.App):
         pass
 
@@ -477,19 +486,19 @@ def test_implicit_parameters():
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @app.path(model=Model, path="foo")
-    def get_model(id):
+    def get_model(id: str) -> Model:
         return Model(id)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "The view for model: %s" % self.id
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -504,7 +513,7 @@ def test_implicit_parameters():
     assert response.body == b"http://localhost/foo?id=bar"
 
 
-def test_implicit_parameters_default():
+def test_implicit_parameters_default() -> None:
     class app(morepath.App):
         pass
 
@@ -513,19 +522,19 @@ def test_implicit_parameters_default():
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @app.path(model=Model, path="foo")
-    def get_model(id="default"):
+    def get_model(id: str = "default") -> Model:
         return Model(id)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "The view for model: %s" % self.id
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -540,7 +549,7 @@ def test_implicit_parameters_default():
     assert response.body == b"http://localhost/foo?id=bar"
 
 
-def test_simple_root():
+def test_simple_root() -> None:
     class app(morepath.App):
         pass
 
@@ -550,11 +559,11 @@ def test_simple_root():
     hello = Hello()
 
     @app.path(model=Hello, path="")
-    def hello_model():
+    def hello_model() -> Hello:
         return hello
 
     @app.view(model=Hello)
-    def hello_view(self, request):
+    def hello_view(self: Hello, request: morepath.Request) -> str:
         return "hello"
 
     c = Client(app())
@@ -563,17 +572,17 @@ def test_simple_root():
     assert response.body == b"hello"
 
 
-def test_json_directive():
+def test_json_directive() -> None:
     class app(morepath.App):
         pass
 
     @app.path(path="{id}")
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @app.json(model=Model)
-    def json(self, request):
+    def json(self: Model, request: morepath.Request) -> dict[str, Any]:
         return {"id": self.id}
 
     c = Client(app())
@@ -582,17 +591,17 @@ def test_json_directive():
     assert response.body == b'{"id":"foo"}'
 
 
-def test_redirect():
+def test_redirect() -> None:
     class app(morepath.App):
         pass
 
     @app.path(path="")
     class Root:
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
     @app.view(model=Root, render=render_html)
-    def default(self, request):
+    def default(self: Root, request: morepath.Request) -> BaseResponse:
         return morepath.redirect("/")
 
     c = Client(app())
@@ -600,7 +609,7 @@ def test_redirect():
     c.get("/", status=302)
 
 
-def test_root_conflict():
+def test_root_conflict() -> None:
     class app(morepath.App):
         pass
 
@@ -616,7 +625,7 @@ def test_root_conflict():
         app.commit()
 
 
-def test_root_conflict2():
+def test_root_conflict2() -> None:
     class app(morepath.App):
         pass
 
@@ -632,7 +641,7 @@ def test_root_conflict2():
         app.commit()
 
 
-def test_root_no_conflict_different_apps():
+def test_root_no_conflict_different_apps() -> None:
     class app_a(morepath.App):
         pass
 
@@ -650,7 +659,7 @@ def test_root_no_conflict_different_apps():
     dectate.commit(app_a, app_b)
 
 
-def test_model_conflict():
+def test_model_conflict() -> None:
     class app(morepath.App):
         pass
 
@@ -658,18 +667,18 @@ def test_model_conflict():
         pass
 
     @app.path(model=A, path="a")
-    def get_a():
+    def get_a() -> A:
         return A()
 
     @app.path(model=A, path="a")
-    def get_a_again():
+    def get_a_again() -> A:
         return A()
 
     with pytest.raises(ConflictError):
         app.commit()
 
 
-def test_path_conflict():
+def test_path_conflict() -> None:
     class app(morepath.App):
         pass
 
@@ -680,18 +689,18 @@ def test_path_conflict():
         pass
 
     @app.path(model=A, path="a")
-    def get_a():
+    def get_a() -> A:
         return A()
 
     @app.path(model=B, path="a")
-    def get_b():
+    def get_b() -> B:
         return B()
 
     with pytest.raises(ConflictError):
         app.commit()
 
 
-def test_path_conflict_with_variable():
+def test_path_conflict_with_variable() -> None:
     class app(morepath.App):
         pass
 
@@ -702,18 +711,18 @@ def test_path_conflict_with_variable():
         pass
 
     @app.path(model=A, path="a/{id}")
-    def get_a(id):
+    def get_a(id: str) -> A:
         return A()
 
     @app.path(model=B, path="a/{id2}")
-    def get_b(id):
+    def get_b(id2: str) -> B:
         return B()
 
     with pytest.raises(ConflictError):
         app.commit()
 
 
-def test_path_conflict_with_variable_different_converters():
+def test_path_conflict_with_variable_different_converters() -> None:
     class app(morepath.App):
         pass
 
@@ -723,19 +732,19 @@ def test_path_conflict_with_variable_different_converters():
     class B:
         pass
 
-    @app.path(model=A, path="a/{id}", converters=Converter(decode=int))
-    def get_a(id):
+    @app.path(model=A, path="a/{id}", converters={"id": Converter(decode=int)})
+    def get_a(id: int) -> A:
         return A()
 
     @app.path(model=B, path="a/{id}")
-    def get_b(id):
+    def get_b(id: str) -> B:
         return B()
 
     with pytest.raises(ConflictError):
         app.commit()
 
 
-def test_model_no_conflict_different_apps():
+def test_model_no_conflict_different_apps() -> None:
     class app_a(morepath.App):
         pass
 
@@ -746,17 +755,17 @@ def test_model_no_conflict_different_apps():
         pass
 
     @app_a.path(model=A, path="a")
-    def get_a():
+    def get_a() -> A:
         return A()
 
     @app_b.path(model=A, path="a")
-    def get_a_again():
+    def get_a_again() -> A:
         return A()
 
     dectate.commit(app_a, app_b)
 
 
-def test_view_conflict():
+def test_view_conflict() -> None:
     class app(morepath.App):
         pass
 
@@ -764,18 +773,18 @@ def test_view_conflict():
         pass
 
     @app.view(model=Model, name="a")
-    def a_view(self, request):
+    def a_view(self: Model, request: morepath.Request) -> None:
         pass
 
     @app.view(model=Model, name="a")
-    def a1_view(self, request):
+    def a1_view(self: Model, request: morepath.Request) -> None:
         pass
 
     with pytest.raises(ConflictError):
         app.commit()
 
 
-def test_view_no_conflict_different_names():
+def test_view_no_conflict_different_names() -> None:
     class app(morepath.App):
         pass
 
@@ -783,17 +792,17 @@ def test_view_no_conflict_different_names():
         pass
 
     @app.view(model=Model, name="a")
-    def a_view(self, request):
+    def a_view(self: Model, request: morepath.Request) -> None:
         pass
 
     @app.view(model=Model, name="b")
-    def b_view(self, request):
+    def b_view(self: Model, request: morepath.Request) -> None:
         pass
 
     app.commit()
 
 
-def test_view_no_conflict_different_predicates():
+def test_view_no_conflict_different_predicates() -> None:
     class app(morepath.App):
         pass
 
@@ -801,17 +810,17 @@ def test_view_no_conflict_different_predicates():
         pass
 
     @app.view(model=Model, name="a", request_method="GET")
-    def a_view(self, request):
+    def a_view(self: Model, request: morepath.Request) -> None:
         pass
 
     @app.view(model=Model, name="a", request_method="POST")
-    def b_view(self, request):
+    def b_view(self: Model, request: morepath.Request) -> None:
         pass
 
     app.commit()
 
 
-def test_view_no_conflict_different_apps():
+def test_view_no_conflict_different_apps() -> None:
     class app_a(morepath.App):
         pass
 
@@ -822,17 +831,17 @@ def test_view_no_conflict_different_apps():
         pass
 
     @app_a.view(model=Model, name="a")
-    def a_view(self, request):
+    def a_view(self: Model, request: morepath.Request) -> None:
         pass
 
     @app_b.view(model=Model, name="a")
-    def a1_view(self, request):
+    def a1_view(self: Model, request: morepath.Request) -> None:
         pass
 
     dectate.commit(app_a, app_b)
 
 
-def test_view_conflict_with_json():
+def test_view_conflict_with_json() -> None:
     class app(morepath.App):
         pass
 
@@ -840,18 +849,18 @@ def test_view_conflict_with_json():
         pass
 
     @app.view(model=Model, name="a")
-    def a_view(self, request):
+    def a_view(self: Model, request: morepath.Request) -> None:
         pass
 
     @app.json(model=Model, name="a")
-    def a1_view(self, request):
+    def a1_view(self: Model, request: morepath.Request) -> None:
         pass
 
     with pytest.raises(ConflictError):
         app.commit()
 
 
-def test_view_conflict_with_html():
+def test_view_conflict_with_html() -> None:
     class app(morepath.App):
         pass
 
@@ -859,28 +868,28 @@ def test_view_conflict_with_html():
         pass
 
     @app.view(model=Model, name="a")
-    def a_view(self, request):
+    def a_view(self: Model, request: morepath.Request) -> None:
         pass
 
     @app.html(model=Model, name="a")
-    def a1_view(self, request):
+    def a1_view(self: Model, request: morepath.Request) -> None:
         pass
 
     with pytest.raises(ConflictError):
         app.commit()
 
 
-def test_function():
+def test_function() -> None:
     class App(morepath.App):
         @morepath.dispatch_method("a")
-        def func(self, a):
+        def func(self, a: Any) -> str:
             return "default"
 
     class A:
         pass
 
     @App.method(App.func, a=A)
-    def a_func(app, request):
+    def a_func(app: App, request: morepath.Request) -> str:
         return "A"
 
     app = App()
@@ -888,17 +897,17 @@ def test_function():
     assert app.func(None) == "default"
 
 
-def test_method():
+def test_method() -> None:
     class App(morepath.App):
         @morepath.dispatch_method("a")
-        def func(self, a):
+        def func(self, a: Any) -> str:
             return "default"
 
     class A:
         pass
 
     @App.method(App.func, a=A)
-    def a_func(app, request):
+    def a_func(app: App, request: morepath.Request) -> str:
         assert isinstance(app, App)
         return "A"
 
@@ -907,31 +916,31 @@ def test_method():
     assert app.func(None) == "default"
 
 
-def test_function_conflict():
+def test_function_conflict() -> None:
     class app(morepath.App):
         @morepath.dispatch_method("a")
-        def func(self, a):
+        def func(self, a: Any) -> None:
             pass
 
     class A:
         pass
 
     @app.method(app.func, a=A)
-    def a_func(app, a, request):
+    def a_func(app: app, a: A, request: morepath.Request) -> None:
         pass
 
     @app.method(app.func, a=A)
-    def a1_func(app, a, request):
+    def a1_func(app: app, a: A, request: morepath.Request) -> None:
         pass
 
     with pytest.raises(ConflictError):
         app.commit()
 
 
-def test_function_no_conflict_different_apps():
+def test_function_no_conflict_different_apps() -> None:
     class base(morepath.App):
         @morepath.dispatch_method("a")
-        def func(self, a):
+        def func(self, a: Any) -> None:
             pass
 
     class app_a(base):
@@ -944,28 +953,27 @@ def test_function_no_conflict_different_apps():
         pass
 
     @app_a.method(base.func, a=A)
-    def a_func(app, a):
+    def a_func(app: app_a, a: A) -> None:
         pass
 
     @app_b.method(base.func, a=A)
-    def a1_func(app, a):
+    def a1_func(app: app_b, a: A) -> None:
         pass
 
     dectate.commit(app_a, app_b)
 
 
-def test_run_app_with_context_without_it():
+def test_run_app_with_context_without_it() -> None:
     class app(morepath.App):
-        pass
 
-        def __init__(self, mount_id):
+        def __init__(self, mount_id: str) -> None:
             self.mount_id = mount_id
 
     with pytest.raises(TypeError):
-        app()
+        app()  # type: ignore
 
 
-def test_mapply_bug():
+def test_mapply_bug() -> None:
     c = Client(mapply_bug.app())
 
     response = c.get("/")
@@ -973,7 +981,7 @@ def test_mapply_bug():
     assert response.body == b"the root"
 
 
-def test_abbr_imperative():
+def test_abbr_imperative() -> None:
     class app(morepath.App):
         pass
 
@@ -981,17 +989,17 @@ def test_abbr_imperative():
         pass
 
     @app.path(path="/", model=Model)
-    def get_model():
+    def get_model() -> Model:
         return Model()
 
     with app.view(model=Model) as view:
 
         @view()
-        def default(self, request):
+        def default(self: Model, request: morepath.Request) -> str:
             return "Default view"
 
         @view(name="edit")
-        def edit(self, request):
+        def edit(self: Model, request: morepath.Request) -> str:
             return "Edit view"
 
     c = Client(app())
@@ -1003,7 +1011,7 @@ def test_abbr_imperative():
     assert response.body == b"Edit view"
 
 
-def test_abbr_exception():
+def test_abbr_partial_imperative() -> None:
     class app(morepath.App):
         pass
 
@@ -1011,20 +1019,50 @@ def test_abbr_exception():
         pass
 
     @app.path(path="/", model=Model)
-    def get_model():
+    def get_model() -> Model:
+        return Model()
+
+    with app.view.partial(model=Model) as view:
+
+        @view()
+        def default(self: Model, request: morepath.Request) -> str:
+            return "Default view"
+
+        @view(name="edit")
+        def edit(self: Model, request: morepath.Request) -> str:
+            return "Edit view"
+
+    c = Client(app())
+
+    response = c.get("/")
+    assert response.body == b"Default view"
+
+    response = c.get("/edit")
+    assert response.body == b"Edit view"
+
+
+def test_abbr_exception() -> None:
+    class app(morepath.App):
+        pass
+
+    class Model:
+        pass
+
+    @app.path(path="/", model=Model)
+    def get_model() -> Model:
         return Model()
 
     try:
         with app.view(model=Model) as view:
 
             @view()
-            def default(self, request):
+            def default(self: Model, request: morepath.Request) -> str:
                 return "Default view"
 
-            1 / 0
+            _ = 1 / 0
 
             @view(name="edit")
-            def edit(self, request):
+            def edit(self: Model, request: morepath.Request) -> str:
                 return "Edit view"
 
     except ZeroDivisionError:
@@ -1039,7 +1077,7 @@ def test_abbr_exception():
     c.get("/edit", status=404)
 
 
-def test_abbr_imperative2():
+def test_abbr_imperative2() -> None:
     class app(morepath.App):
         pass
 
@@ -1047,17 +1085,17 @@ def test_abbr_imperative2():
         pass
 
     @app.path(path="/", model=Model)
-    def get_model():
+    def get_model() -> Model:
         return Model()
 
     with app.view(model=Model) as view:
 
         @view()
-        def default(self, request):
+        def default(self: Model, request: morepath.Request) -> str:
             return "Default view"
 
         @view(name="edit")
-        def edit(self, request):
+        def edit(self: Model, request: morepath.Request) -> str:
             return "Edit view"
 
     c = Client(app())
@@ -1069,7 +1107,7 @@ def test_abbr_imperative2():
     assert response.body == b"Edit view"
 
 
-def test_abbr_nested():
+def test_abbr_nested() -> None:
     class app(morepath.App):
         pass
 
@@ -1077,23 +1115,23 @@ def test_abbr_nested():
         pass
 
     @app.path(path="/", model=Model)
-    def get_model():
+    def get_model() -> Model:
         return Model()
 
     with app.view(model=Model) as view:
 
         @view()
-        def default(self, request):
+        def default(self: Model, request: morepath.Request) -> str:
             return "Default"
 
         with view(name="extra") as view:
 
             @view()
-            def get(self, request):
+            def get(self: Model, request: morepath.Request) -> str:
                 return "Get"
 
             @view(request_method="POST")
-            def post(self, request):
+            def post(self: Model, request: morepath.Request) -> str:
                 return "Post"
 
     c = Client(app())
@@ -1108,21 +1146,21 @@ def test_abbr_nested():
     assert response.body == b"Post"
 
 
-def test_function_directive():
+def test_function_directive() -> None:
     class app(morepath.App):
         @morepath.dispatch_method("o")
-        def mygeneric(self, o):
+        def mygeneric(self, o: Any) -> str:
             return "The object: %s" % o
 
     class Foo:
-        def __init__(self, value):
+        def __init__(self, value: int) -> None:
             self.value = value
 
-        def __repr__(self):
+        def __repr__(self) -> str:
             return "<Foo with value: %s>" % self.value
 
     @app.method(app.mygeneric, o=Foo)
-    def mygeneric_for_foo(app, o):
+    def mygeneric_for_foo(app: app, o: Foo) -> str:
         return "The foo object: %s" % o
 
     a = app()
@@ -1131,17 +1169,17 @@ def test_function_directive():
     assert a.mygeneric(Foo(1)) == ("The foo object: <Foo with value: 1>")
 
 
-def test_classgeneric_function_directive():
+def test_classgeneric_function_directive() -> None:
     class app(morepath.App):
         @morepath.dispatch_method(reg.match_class("o"))
-        def mygeneric(self, o):
+        def mygeneric(self, o: Any) -> str:
             return "The object"
 
     class Foo:
         pass
 
     @app.method(app.mygeneric, o=Foo)
-    def mygeneric_for_foo(app, o):
+    def mygeneric_for_foo(app: app, o: Foo) -> str:
         return "The foo object"
 
     a = app()
@@ -1150,7 +1188,7 @@ def test_classgeneric_function_directive():
     assert a.mygeneric(Foo) == "The foo object"
 
 
-def test_staticmethod():
+def test_staticmethod() -> None:
     class App(morepath.App):
         pass
 
@@ -1161,7 +1199,10 @@ def test_staticmethod():
     class A:
         @staticmethod
         @App.view(model=Root)
-        def root_default(self, request):
+        def root_default(
+            self: Root,  # pyright: ignore[reportSelfClsParameterName]
+            request: morepath.Request,
+        ) -> str:
             assert isinstance(self, Root)
             return "Hello world"
 
@@ -1171,7 +1212,7 @@ def test_staticmethod():
     assert response.body == b"Hello world"
 
 
-def test_classmethod_equivalent_to_staticmethod():
+def test_classmethod_equivalent_to_staticmethod() -> None:
     class App(morepath.App):
         pass
 
@@ -1182,7 +1223,10 @@ def test_classmethod_equivalent_to_staticmethod():
     class A:
         @classmethod
         @App.view(model=Root)
-        def root_default(self, request):
+        def root_default(
+            self: Any,  # pyright: ignore[reportSelfClsParameterName]
+            request: morepath.Request,
+        ) -> str:
             assert isinstance(self, Root)
             return "Hello world"
 
@@ -1192,7 +1236,7 @@ def test_classmethod_equivalent_to_staticmethod():
     assert response.body == b"Hello world"
 
 
-def test_classmethod_bound_outside():
+def test_classmethod_bound_outside() -> None:
     class App(morepath.App):
         pass
 
@@ -1202,7 +1246,7 @@ def test_classmethod_bound_outside():
 
     class A:
         @classmethod
-        def root_default(cls, self, request):
+        def root_default(cls, self: Root, request: morepath.Request) -> str:
             assert isinstance(self, Root)
             return "Hello world"
 
@@ -1214,7 +1258,7 @@ def test_classmethod_bound_outside():
     assert response.body == b"Hello world"
 
 
-def test_instantiation_before_config():
+def test_instantiation_before_config() -> None:
     class App(morepath.App):
         pass
 
@@ -1228,7 +1272,7 @@ def test_instantiation_before_config():
         pass
 
     @App.view(model=Hello)
-    def hello_view(self, request):
+    def hello_view(self: App, request: morepath.Request) -> str:
         return "hello"
 
     c = Client(app)

--- a/morepath/tests/test_error.py
+++ b/morepath/tests/test_error.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import dectate
@@ -7,7 +9,7 @@ from dectate import ConflictError, DirectiveReportError
 from .fixtures import conflicterror
 
 
-def test_missing_arguments_in_path_function_error():
+def test_missing_arguments_in_path_function_error() -> None:
     class App(morepath.App):
         pass
 
@@ -15,46 +17,46 @@ def test_missing_arguments_in_path_function_error():
         pass
 
     @App.path(path="{id}", model=Model)
-    def get_model():
+    def get_model() -> Model:
         return Model()
 
     with pytest.raises(DirectiveReportError):
         dectate.commit(App)
 
 
-def test_path_function_with_args_error():
+def test_path_function_with_args_error() -> None:
     class App(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @App.path(path="{id}", model=Model)
-    def get_model(*args):
+    def get_model(*args: str) -> Model:
         return Model(args[0])
 
     with pytest.raises(DirectiveReportError):
         dectate.commit(App)
 
 
-def test_path_function_with_kwargs():
+def test_path_function_with_kwargs() -> None:
     class App(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @App.path(path="{id}", model=Model)
-    def get_model(**kw):
+    def get_model(**kw: str) -> Model:
         return Model(kw["id"])
 
     with pytest.raises(DirectiveReportError):
         dectate.commit(App)
 
 
-def test_conflict_error_should_report_line_numbers():
+def test_conflict_error_should_report_line_numbers() -> None:
     with pytest.raises(ConflictError) as e:
         dectate.commit(conflicterror.App)
     v = str(e.value)

--- a/morepath/tests/test_excview.py
+++ b/morepath/tests/test_excview.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from webob.exc import HTTPNotFound
 from webtest import TestApp as Client
@@ -5,7 +7,7 @@ from webtest import TestApp as Client
 import morepath
 
 
-def test_404_http_exception():
+def test_404_http_exception() -> None:
     class app(morepath.App):
         pass
 
@@ -17,7 +19,7 @@ def test_404_http_exception():
     c.get("/", status=404)
 
 
-def test_other_exception_not_handled():
+def test_other_exception_not_handled() -> None:
     class app(morepath.App):
         pass
 
@@ -29,7 +31,7 @@ def test_other_exception_not_handled():
         pass
 
     @app.view(model=Root)
-    def root_default(self, request):
+    def root_default(self: Root, request: morepath.Request) -> None:
         raise MyException()
 
     c = Client(app())
@@ -40,7 +42,7 @@ def test_other_exception_not_handled():
         c.get("/")
 
 
-def test_http_exception_excview():
+def test_http_exception_excview() -> None:
     class app(morepath.App):
         pass
 
@@ -49,7 +51,7 @@ def test_http_exception_excview():
         pass
 
     @app.view(model=HTTPNotFound)
-    def notfound_default(self, request):
+    def notfound_default(self: HTTPNotFound, request: morepath.Request) -> str:
         return "Not found!"
 
     c = Client(app())
@@ -57,7 +59,7 @@ def test_http_exception_excview():
     assert response.body == b"Not found!"
 
 
-def test_other_exception_excview():
+def test_other_exception_excview() -> None:
     class app(morepath.App):
         pass
 
@@ -69,11 +71,13 @@ def test_other_exception_excview():
         pass
 
     @app.view(model=Root)
-    def root_default(self, request):
+    def root_default(self: Root, request: morepath.Request) -> None:
         raise MyException()
 
     @app.view(model=MyException)
-    def myexception_default(self, request):
+    def myexception_default(
+        self: MyException, request: morepath.Request
+    ) -> str:
         return "My exception"
 
     c = Client(app())
@@ -82,7 +86,7 @@ def test_other_exception_excview():
     assert response.body == b"My exception"
 
 
-def test_http_exception_excview_retain_status():
+def test_http_exception_excview_retain_status() -> None:
     class app(morepath.App):
         pass
 
@@ -91,8 +95,8 @@ def test_http_exception_excview_retain_status():
         pass
 
     @app.view(model=HTTPNotFound)
-    def notfound_default(self, request):
-        def set_status(response):
+    def notfound_default(self: HTTPNotFound, request: morepath.Request) -> str:
+        def set_status(response: morepath.Response) -> None:
             response.status_code = self.code
 
         request.after(set_status)
@@ -103,7 +107,7 @@ def test_http_exception_excview_retain_status():
     assert response.body == b"Not found!!"
 
 
-def test_excview_named_view():
+def test_excview_named_view() -> None:
     class app(morepath.App):
         pass
 
@@ -115,12 +119,14 @@ def test_excview_named_view():
         pass
 
     @app.view(model=Root, name="view")
-    def view(self, request):
+    def view(self: Root, request: morepath.Request) -> None:
         raise MyException()
 
     # the view name should have no influence on myexception lookup
     @app.view(model=MyException)
-    def myexception_default(self, request):
+    def myexception_default(
+        self: MyException, request: morepath.Request
+    ) -> str:
         return "My exception"
 
     c = Client(app())
@@ -128,7 +134,7 @@ def test_excview_named_view():
     assert response.body == b"My exception"
 
 
-def test_excview_in_mounted_app():
+def test_excview_in_mounted_app() -> None:
     class App(morepath.App):
         pass
 
@@ -136,14 +142,14 @@ def test_excview_in_mounted_app():
         pass
 
     @App.mount(app=Sub, path="sub")
-    def mount_sub():
+    def mount_sub() -> Sub:
         return Sub()
 
     class Error(Exception):
         pass
 
     @Sub.view(model=Error)
-    def error_default(self, request):
+    def error_default(self: Error, request: morepath.Request) -> str:
         return "Default error"
 
     @Sub.path(path="/")
@@ -151,7 +157,7 @@ def test_excview_in_mounted_app():
         pass
 
     @Sub.view(model=SubRoot)
-    def subroot_default(self, request):
+    def subroot_default(self: SubRoot, request: morepath.Request) -> None:
         raise Error()
 
     c = Client(App())

--- a/morepath/tests/test_extend.py
+++ b/morepath/tests/test_extend.py
@@ -1,12 +1,16 @@
+from __future__ import annotations
+
+from typing import Any
+
 from webtest import TestApp as Client
 
 import morepath
 
 
-def test_function_extends():
+def test_function_extends() -> None:
     class App(morepath.App):
         @morepath.dispatch_method("obj")
-        def foo(self, obj):
+        def foo(self, obj: Any) -> str:
             return "default"
 
     class Extending(App):
@@ -16,18 +20,18 @@ def test_function_extends():
         pass
 
     @App.method(App.foo, obj=Alpha)
-    def app_foo(app, obj):
+    def app_foo(app: App, obj: Alpha) -> str:
         return "App"
 
     @Extending.method(App.foo, obj=Alpha)
-    def extending_foo(app, obj):
+    def extending_foo(app: Extending, obj: Alpha) -> str:
         return "Extending"
 
     assert App().foo(Alpha()) == "App"
     assert Extending().foo(Alpha()) == "Extending"
 
 
-def test_extends():
+def test_extends() -> None:
     class App(morepath.App):
         pass
 
@@ -36,15 +40,15 @@ def test_extends():
 
     @App.path(path="users/{username}")
     class User:
-        def __init__(self, username):
+        def __init__(self, username: str) -> None:
             self.username = username
 
     @App.view(model=User)
-    def render_user(self, request):
+    def render_user(self: User, request: morepath.Request) -> str:
         return "User: %s" % self.username
 
     @Extending.view(model=User, name="edit")
-    def edit_user(self, request):
+    def edit_user(self: User, request: morepath.Request) -> str:
         return "Edit user: %s" % self.username
 
     cl = Client(App())
@@ -59,7 +63,7 @@ def test_extends():
     assert response.body == b"Edit user: foo"
 
 
-def test_overrides_view():
+def test_overrides_view() -> None:
     class App(morepath.App):
         pass
 
@@ -68,15 +72,15 @@ def test_overrides_view():
 
     @App.path(path="users/{username}")
     class User:
-        def __init__(self, username):
+        def __init__(self, username: str) -> None:
             self.username = username
 
     @App.view(model=User)
-    def render_user(self, request):
+    def render_user(self: User, request: morepath.Request) -> str:
         return "User: %s" % self.username
 
     @Overriding.view(model=User)
-    def render_user2(self, request):
+    def render_user2(self: User, request: morepath.Request) -> str:
         return "USER: %s" % self.username
 
     cl = Client(App())
@@ -88,7 +92,7 @@ def test_overrides_view():
     assert response.body == b"USER: foo"
 
 
-def test_overrides_model():
+def test_overrides_model() -> None:
     class App(morepath.App):
         pass
 
@@ -97,15 +101,15 @@ def test_overrides_model():
 
     @App.path(path="users/{username}")
     class User:
-        def __init__(self, username):
+        def __init__(self, username: str) -> None:
             self.username = username
 
     @App.view(model=User)
-    def render_user(self, request):
+    def render_user(self: User, request: morepath.Request) -> str:
         return "User: %s" % self.username
 
     @Overriding.path(model=User, path="users/{username}")
-    def get_user(username):
+    def get_user(username: str) -> User | None:
         if username != "bar":
             return None
         return User(username)

--- a/morepath/tests/test_init_settings.py
+++ b/morepath/tests/test_init_settings.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import morepath
@@ -5,7 +7,7 @@ from morepath.error import ConflictError
 from morepath.tests.fixtures.config import settings as settings_file
 
 
-def test_init_settings():
+def test_init_settings() -> None:
 
     settings_dict = {
         "foo": {"enable_foo": True, "engine": "ADVANCED"},
@@ -26,7 +28,7 @@ def test_init_settings():
     assert app.settings.bar.security is False
 
 
-def test_app_extends_settings():
+def test_app_extends_settings() -> None:
     class Alpha(morepath.App):
         pass
 
@@ -53,7 +55,7 @@ def test_app_extends_settings():
     assert settings.bar.space == "huge"
 
 
-def test_app_overrides_settings():
+def test_app_overrides_settings() -> None:
     class Alpha(morepath.App):
         pass
 
@@ -84,7 +86,7 @@ def test_app_overrides_settings():
     assert settings.bar.space == "tiny"
 
 
-def test_section_settings_conflict():
+def test_section_settings_conflict() -> None:
 
     settings = {
         "foo": {"enable_foo": True, "engine": "ADVANCED"},
@@ -97,14 +99,14 @@ def test_section_settings_conflict():
     App.init_settings(settings)
 
     @App.setting("foo", "engine")
-    def get_foo_setting():
+    def get_foo_setting() -> str:
         return "STANDARD"
 
     with pytest.raises(ConflictError):
         morepath.commit(App)
 
 
-def test_extentions_settings():
+def test_extentions_settings() -> None:
 
     settings_dict = settings_file.settings
 

--- a/morepath/tests/test_internal.py
+++ b/morepath/tests/test_internal.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
+from typing import Any
+
 from webtest import TestApp as Client
 
 import morepath
 
 
-def test_internal():
+def test_internal() -> None:
     class app(morepath.App):
         pass
 
@@ -12,11 +16,11 @@ def test_internal():
         pass
 
     @app.json(model=Root)
-    def root_default(self, request):
+    def root_default(self: Root, request: morepath.Request) -> dict[str, Any]:
         return {"internal": request.view(self, name="internal")}
 
     @app.json(model=Root, name="internal", internal=True)
-    def root_internal(self, request):
+    def root_internal(self: Root, request: morepath.Request) -> str:
         return "Internal!"
 
     c = Client(app())

--- a/morepath/tests/test_json_obj.py
+++ b/morepath/tests/test_json_obj.py
@@ -1,23 +1,29 @@
+from __future__ import annotations
+
+from typing import Any
+
 from webtest import TestApp as Client
 
 import morepath
 
 
-def test_json_obj_dump():
+def test_json_obj_dump() -> None:
     class app(morepath.App):
         pass
 
     @app.path(path="/models/{x}")
     class Model:
-        def __init__(self, x):
+        def __init__(self, x: str) -> None:
             self.x = x
 
     @app.json(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> Model:
         return self
 
     @app.dump_json(model=Model)
-    def dump_model_json(self, request):
+    def dump_model_json(
+        self: Model, request: morepath.Request
+    ) -> dict[str, Any]:
         return {"x": self.x}
 
     c = Client(app())
@@ -26,21 +32,23 @@ def test_json_obj_dump():
     assert response.json == {"x": "foo"}
 
 
-def test_json_obj_dump_app_arg():
+def test_json_obj_dump_app_arg() -> None:
     class App(morepath.App):
         pass
 
     @App.path(path="/models/{x}")
     class Model:
-        def __init__(self, x):
+        def __init__(self, x: str) -> None:
             self.x = x
 
     @App.json(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> Model:
         return self
 
     @App.dump_json(model=Model)
-    def dump_model_json(app, obj, request):
+    def dump_model_json(
+        app: App, obj: Model, request: morepath.Request
+    ) -> dict[str, Any]:
         assert isinstance(app, App)
         return {"x": obj.x}
 

--- a/morepath/tests/test_link.py
+++ b/morepath/tests/test_link.py
@@ -1,11 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeAlias
+
 import pytest
 
 from morepath.app import App
 from morepath.converter import Converter
 
+if TYPE_CHECKING:
+    from morepath.path import PathRegistry
+
+    Info: TypeAlias = tuple[App, PathRegistry]
+
 
 @pytest.fixture
-def info():
+def info() -> Info:
     class MyApp(App):
         pass
 
@@ -16,108 +25,115 @@ def info():
     return app, r
 
 
-def test_path_without_variables(info):
+def test_path_without_variables(info: Info) -> None:
     app, r = info
 
     class Foo:
         pass
 
     r.register_inverse_path(model=Foo, path="/", factory_args=set())
-    info = app._get_path(Foo())
-    assert info.path == ""
-    assert info.parameters == {}
+    path_info = app._get_path(Foo())
+    assert path_info is not None
+    assert path_info.path == ""
+    assert path_info.parameters == {}
 
 
-def test_path_with_variables(info):
+def test_path_with_variables(info: Info) -> None:
     app, r = info
 
     class Foo:
-        def __init__(self, name):
+        def __init__(self, name: str) -> None:
             self.name = name
 
     r.register_path_variables(Foo, lambda obj: {"name": obj.name})
     r.register_inverse_path(
         model=Foo, path="/foos/{name}", factory_args={"name"}
     )
-    info = app._get_path(Foo("a"))
-    assert info.path == "foos/a"
-    assert info.parameters == {}
+    path_info = app._get_path(Foo("a"))
+    assert path_info is not None
+    assert path_info.path == "foos/a"
+    assert path_info.parameters == {}
 
 
-def test_path_with_default_variables(info):
+def test_path_with_default_variables(info: Info) -> None:
     app, r = info
 
     class Foo:
-        def __init__(self, name):
+        def __init__(self, name: str) -> None:
             self.name = name
 
     r.register_inverse_path(
         model=Foo, path="/foos/{name}", factory_args={"name"}
     )
-    info = app._get_path(Foo("a"))
-    assert info.path == "foos/a"
-    assert info.parameters == {}
+    path_info = app._get_path(Foo("a"))
+    assert path_info is not None
+    assert path_info.path == "foos/a"
+    assert path_info.parameters == {}
 
 
-def test_path_with_parameters(info):
+def test_path_with_parameters(info: Info) -> None:
     app, r = info
 
     class Foo:
-        def __init__(self, name):
+        def __init__(self, name: str) -> None:
             self.name = name
 
     r.register_path_variables(Foo, lambda obj: {"name": obj.name})
     r.register_inverse_path(model=Foo, path="/foos", factory_args={"name"})
-    info = app._get_path(Foo("a"))
-    assert info.path == "foos"
-    assert info.parameters == {"name": ["a"]}
+    path_info = app._get_path(Foo("a"))
+    assert path_info is not None
+    assert path_info.path == "foos"
+    assert path_info.parameters == {"name": ["a"]}
 
 
-def test_class_path_without_variables(info):
+def test_class_path_without_variables(info: Info) -> None:
     app, r = info
 
     class Foo:
         pass
 
     r.register_inverse_path(model=Foo, path="/", factory_args=set())
-    info = app._class_path(Foo, {})
-    assert info.path == ""
-    assert info.parameters == {}
+    path_info = app._class_path(Foo, {})
+    assert path_info is not None
+    assert path_info.path == ""
+    assert path_info.parameters == {}
 
 
-def test_class_path_with_variables(info):
+def test_class_path_with_variables(info: Info) -> None:
     app, r = info
 
     class Foo:
-        def __init__(self, name):
+        def __init__(self, name: str) -> None:
             self.name = name
 
     r.register_inverse_path(
         model=Foo, path="/foos/{name}", factory_args={"name"}
     )
-    info = app._class_path(Foo, {"name": "a"})
-    assert info.path == "foos/a"
-    assert info.parameters == {}
+    path_info = app._class_path(Foo, {"name": "a"})
+    assert path_info is not None
+    assert path_info.path == "foos/a"
+    assert path_info.parameters == {}
 
 
-def test_class_path_with_parameters(info):
+def test_class_path_with_parameters(info: Info) -> None:
     app, r = info
 
     class Foo:
-        def __init__(self, name):
+        def __init__(self, name: str) -> None:
             self.name = name
 
     r.register_inverse_path(model=Foo, path="/foos", factory_args={"name"})
-    info = app._class_path(Foo, {"name": "a"})
-    assert info.path == "foos"
-    assert info.parameters == {"name": ["a"]}
+    path_info = app._class_path(Foo, {"name": "a"})
+    assert path_info is not None
+    assert path_info.path == "foos"
+    assert path_info.parameters == {"name": ["a"]}
 
 
-def test_class_path_variables_with_converters(info):
+def test_class_path_variables_with_converters(info: Info) -> None:
     app, r = info
 
     class Foo:
-        def __init__(self, value):
+        def __init__(self, value: int) -> None:
             self.value = value
 
     r.register_inverse_path(
@@ -126,16 +142,17 @@ def test_class_path_variables_with_converters(info):
         factory_args={"value"},
         converters={"value": Converter(int)},
     )
-    info = app._class_path(Foo, {"value": 1})
-    assert info.path == "foos/1"
-    assert info.parameters == {}
+    path_info = app._class_path(Foo, {"value": 1})
+    assert path_info is not None
+    assert path_info.path == "foos/1"
+    assert path_info.parameters == {}
 
 
-def test_class_path_parameters_with_converters(info):
+def test_class_path_parameters_with_converters(info: Info) -> None:
     app, r = info
 
     class Foo:
-        def __init__(self, value):
+        def __init__(self, value: int) -> None:
             self.value = value
 
     r.register_inverse_path(
@@ -144,12 +161,13 @@ def test_class_path_parameters_with_converters(info):
         factory_args={"value"},
         converters={"value": Converter(int)},
     )
-    info = app._class_path(Foo, {"value": 1})
-    assert info.path == "foos"
-    assert info.parameters == {"value": ["1"]}
+    path_info = app._class_path(Foo, {"value": 1})
+    assert path_info is not None
+    assert path_info.path == "foos"
+    assert path_info.parameters == {"value": ["1"]}
 
 
-def test_class_path_absorb(info):
+def test_class_path_absorb(info: Info) -> None:
     app, r = info
 
     class Foo:
@@ -158,24 +176,26 @@ def test_class_path_absorb(info):
     r.register_inverse_path(
         model=Foo, path="/foos", factory_args=set(), absorb=True
     )
-    info = app._class_path(Foo, {"absorb": "bar"})
-    assert info.path == "foos/bar"
-    assert info.parameters == {}
+    path_info = app._class_path(Foo, {"absorb": "bar"})
+    assert path_info is not None
+    assert path_info.path == "foos/bar"
+    assert path_info.parameters == {}
 
 
-def test_class_path_extra_parameters(info):
+def test_class_path_extra_parameters(info: Info) -> None:
     app, r = info
 
     class Foo:
         pass
 
     r.register_inverse_path(model=Foo, path="/foos", factory_args=set())
-    info = app._class_path(Foo, {"extra_parameters": {"a": "A", "b": "B"}})
-    assert info.path == "foos"
-    assert info.parameters == {"a": ["A"], "b": ["B"]}
+    path_info = app._class_path(Foo, {"extra_parameters": {"a": "A", "b": "B"}})
+    assert path_info is not None
+    assert path_info.path == "foos"
+    assert path_info.parameters == {"a": ["A"], "b": ["B"]}
 
 
-def test_class_path_extra_parameters_convert(info):
+def test_class_path_extra_parameters_convert(info: Info) -> None:
     app, r = info
 
     class Foo:
@@ -187,6 +207,7 @@ def test_class_path_extra_parameters_convert(info):
         factory_args=set(),
         converters={"a": Converter(int)},
     )
-    info = app._class_path(Foo, {"extra_parameters": {"a": 1, "b": "B"}})
-    assert info.path == "foos"
-    assert info.parameters == {"a": ["1"], "b": ["B"]}
+    path_info = app._class_path(Foo, {"extra_parameters": {"a": 1, "b": "B"}})
+    assert path_info is not None
+    assert path_info.path == "foos"
+    assert path_info.parameters == {"a": ["1"], "b": ["B"]}

--- a/morepath/tests/test_load.py
+++ b/morepath/tests/test_load.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
+from typing import Any
+
 import pytest
 from webtest import TestApp as Client
 
 import morepath
 
 
-def test_load():
+def test_load() -> None:
     class App(morepath.App):
         pass
 
@@ -12,11 +16,11 @@ def test_load():
     class Root:
         pass
 
-    def load(request):
+    def load(request: morepath.Request) -> Any:
         return request.json
 
     @App.view(model=Root, request_method="POST", load=load)
-    def root_post(self, request, obj):
+    def root_post(self: Root, request: morepath.Request, obj: Any) -> str:
         return "true" if obj == {"foo": "bar"} else "false"
 
     app = App()
@@ -27,7 +31,7 @@ def test_load():
     assert r.body == b"true"
 
 
-def test_load_requires_three_arguments():
+def test_load_requires_three_arguments() -> None:
     class App(morepath.App):
         pass
 
@@ -35,11 +39,11 @@ def test_load_requires_three_arguments():
     class Root:
         pass
 
-    def load(request):
+    def load(request: morepath.Request) -> Any:
         return request.json
 
     @App.view(model=Root, request_method="POST", load=load)
-    def root_post(self, request):
+    def root_post(self: Root, request: morepath.Request) -> None:
         pass
 
     app = App()
@@ -51,7 +55,7 @@ def test_load_requires_three_arguments():
         client.post_json("/", {"foo": "bar"})
 
 
-def test_load_json():
+def test_load_json() -> None:
     class App(morepath.App):
         pass
 
@@ -59,11 +63,11 @@ def test_load_json():
     class Root:
         pass
 
-    def load(request):
+    def load(request: morepath.Request) -> Any:
         return request.json
 
     @App.json(model=Root, request_method="POST", load=load)
-    def root_post(self, request, obj):
+    def root_post(self: Root, request: morepath.Request, obj: Any) -> str:
         return "true" if obj == {"foo": "bar"} else "false"
 
     app = App()
@@ -74,7 +78,7 @@ def test_load_json():
     assert r.body == b'"true"'
 
 
-def test_load_html():
+def test_load_html() -> None:
     class App(morepath.App):
         pass
 
@@ -82,11 +86,11 @@ def test_load_html():
     class Root:
         pass
 
-    def load(request):
+    def load(request: morepath.Request) -> Any:
         return request.json
 
     @App.html(model=Root, request_method="POST", load=load)
-    def root_post(self, request, obj):
+    def root_post(self: Root, request: morepath.Request, obj: Any) -> str:
         return "true" if obj == {"foo": "bar"} else "false"
 
     app = App()

--- a/morepath/tests/test_mapply.py
+++ b/morepath/tests/test_mapply.py
@@ -1,34 +1,36 @@
+from __future__ import annotations
+
 import pytest
 
 from ..mapply import mapply
 
 
-def test_mapply():
-    def foo(a):
+def test_mapply() -> None:
+    def foo(a: int) -> str:
         return "foo with %s" % a
 
     assert mapply(foo, a=1) == "foo with 1"
     assert mapply(foo, a=1, b=2) == "foo with 1"
 
 
-def test_mapply_fail():
-    def foo(a):
+def test_mapply_fail() -> None:
+    def foo(a: int) -> str:
         return "foo with %s" % a
 
     with pytest.raises(TypeError):
         mapply(foo, b=2)
 
 
-def test_mapply_args():
-    def foo(a):
+def test_mapply_args() -> None:
+    def foo(a: int) -> str:
         return "foo with %s" % a
 
     assert mapply(foo, 1) == "foo with 1"
 
 
-def test_mapply_with_method():
+def test_mapply_with_method() -> None:
     class Foo:
-        def method(self, a):
+        def method(self, a: int) -> str:
             return "method with %s" % a
 
     f = Foo()
@@ -36,27 +38,27 @@ def test_mapply_with_method():
     assert mapply(f.method, a=1, b=2) == "method with 1"
 
 
-def test_mapply_with_constructor():
+def test_mapply_with_constructor() -> None:
     class Foo:
-        def __init__(self, a):
+        def __init__(self, a: int) -> None:
             self.a = a
 
     assert mapply(Foo, a=1).a == 1
     assert mapply(Foo, a=1, b=1).a == 1
 
 
-def test_mapply_with_old_style_class():
+def test_mapply_with_old_style_class() -> None:
     class Foo:
-        def __init__(self, a):
+        def __init__(self, a: int) -> None:
             self.a = a
 
     assert mapply(Foo, a=1).a == 1
     assert mapply(Foo, a=1, b=1).a == 1
 
 
-def test_mapply_callable_object():
+def test_mapply_callable_object() -> None:
     class Foo:
-        def __call__(self, a):
+        def __call__(self, a: int) -> str:
             return "called with %s" % a
 
     f = Foo()
@@ -64,34 +66,34 @@ def test_mapply_callable_object():
     assert mapply(f, a=1, b=1) == "called with 1"
 
 
-def test_mapply_non_function():
+def test_mapply_non_function() -> None:
     a = 1
 
     with pytest.raises(Exception):
-        assert mapply(a, a=1)
+        assert mapply(a, a=1)  # type: ignore
 
 
-def test_mapply_builtin():
+def test_mapply_builtin() -> None:
     assert mapply(int, "1") == 1
 
 
-def test_mapply_kw():
-    def foo(**kw):
+def test_mapply_kw() -> None:
+    def foo(**kw: int) -> dict[str, int]:
         return kw
 
     assert mapply(foo, a=1) == {"a": 1}
 
 
-def test_mapply_args2():
-    def foo(*args):
+def test_mapply_args2() -> None:
+    def foo(*args: int) -> tuple[int, ...]:
         return args
 
     assert mapply(foo, a=1) == ()
     assert mapply(foo, 1) == (1,)
 
 
-def test_mapply_args_kw():
-    def foo(*args, **kw):
+def test_mapply_args_kw() -> None:
+    def foo(*args: int, **kw: int) -> tuple[tuple[int, ...], dict[str, int]]:
         return args, kw
 
     assert mapply(foo, a=1) == ((), {"a": 1})
@@ -99,8 +101,10 @@ def test_mapply_args_kw():
     assert mapply(foo, 1, a=1) == ((1,), {"a": 1})
 
 
-def test_mapply_all_args_kw():
-    def foo(a, *args, **kw):
+def test_mapply_all_args_kw() -> None:
+    def foo(
+        a: int, *args: int, **kw: int
+    ) -> tuple[int, tuple[int, ...], dict[str, int]]:
         return a, args, kw
 
     assert mapply(foo, 1) == (1, (), {})
@@ -108,31 +112,31 @@ def test_mapply_all_args_kw():
     assert mapply(foo, 2, 3, b=1) == (2, (3,), {"b": 1})
 
 
-def test_mapply_class():
+def test_mapply_class() -> None:
     class Foo:
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
     assert isinstance(mapply(Foo), Foo)
 
 
-def test_mapply_class_too_much():
+def test_mapply_class_too_much() -> None:
     class Foo:
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
     assert isinstance(mapply(Foo, a=1), Foo)
 
 
-def test_mapply_classic_class_too_much():
+def test_mapply_classic_class_too_much() -> None:
     class Foo:
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
     assert isinstance(mapply(Foo, a=1), Foo)
 
 
-def test_mapply_class_no_init_too_much():
+def test_mapply_class_no_init_too_much() -> None:
     class Foo:
         pass
 
@@ -140,33 +144,33 @@ def test_mapply_class_no_init_too_much():
     assert isinstance(mapply(Foo, **variables), Foo)
 
 
-def test_mapply_classic_class_no_init_too_much():
+def test_mapply_classic_class_no_init_too_much() -> None:
     class Foo:
         pass
 
     assert isinstance(mapply(Foo, a=1), Foo)
 
 
-def test_mapply_kw_class():
+def test_mapply_kw_class() -> None:
     class Foo:
-        def __init__(self, **kw):
+        def __init__(self, **kw: int) -> None:
             self.kw = kw
 
     assert mapply(Foo, a=1).kw == {"a": 1}
 
 
-def test_mapply_args_class():
+def test_mapply_args_class() -> None:
     class Foo:
-        def __init__(self, *args):
+        def __init__(self, *args: int) -> None:
             self.args = args
 
     assert mapply(Foo, a=1).args == ()
     assert mapply(Foo, 1).args == (1,)
 
 
-def test_mapply_args_kw_class():
+def test_mapply_args_kw_class() -> None:
     class Foo:
-        def __init__(self, *args, **kw):
+        def __init__(self, *args: int, **kw: int) -> None:
             self.args = args
             self.kw = kw
 
@@ -178,9 +182,9 @@ def test_mapply_args_kw_class():
     assert (r.args, r.kw) == ((1,), {"a": 1})
 
 
-def test_mapply_all_args_kw_class():
+def test_mapply_all_args_kw_class() -> None:
     class Foo:
-        def __init__(self, a, *args, **kw):
+        def __init__(self, a: int, *args: int, **kw: int) -> None:
             self.a = a
             self.args = args
             self.kw = kw

--- a/morepath/tests/test_method_directive.py
+++ b/morepath/tests/test_method_directive.py
@@ -1,33 +1,35 @@
+from __future__ import annotations
+
 from webtest import TestApp as Client
 
 import morepath
 
 
-def test_implicit_function():
+def test_implicit_function() -> None:
     class app(morepath.App):
         @morepath.dispatch_method()
-        def one(self):
+        def one(self) -> str:
             return "Default one"
 
         @morepath.dispatch_method()
-        def two(self):
+        def two(self) -> str:
             return "Default two"
 
     @app.path(path="")
     class Model:
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
     @app.method(app.one)
-    def one_impl(self):
+    def one_impl(self: app) -> str:
         return self.two()
 
     @app.method(app.two)
-    def two_impl(self):
+    def two_impl(self: app) -> str:
         return "The real two"
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request[app]) -> str:
         return request.app.one()
 
     c = Client(app())
@@ -36,56 +38,56 @@ def test_implicit_function():
     assert response.body == b"The real two"
 
 
-def test_implicit_function_mounted():
+def test_implicit_function_mounted() -> None:
     class base(morepath.App):
         @morepath.dispatch_method()
-        def one(self):
+        def one(self) -> str:
             return "Default one"
 
         @morepath.dispatch_method()
-        def two(self):
+        def two(self) -> str:
             return "Default two"
 
     class alpha(base):
         pass
 
     class beta(base):
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @alpha.mount(path="mounted/{id}", app=beta)
-    def mount_beta(id):
+    def mount_beta(id: str) -> beta:
         return beta(id=id)
 
     class AlphaRoot:
         pass
 
     class Root:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @alpha.path(path="/", model=AlphaRoot)
-    def get_alpha_root():
+    def get_alpha_root() -> AlphaRoot:
         return AlphaRoot()
 
     @beta.path(path="/", model=Root)
-    def get_root(app):
+    def get_root(app: beta) -> Root:
         return Root(app.id)
 
     @beta.method(base.one)
-    def one_impl(self):
+    def one_impl(self: beta) -> str:
         return self.two()
 
     @beta.method(base.two)
-    def two_impl(self):
+    def two_impl(self: beta) -> str:
         return "The real two"
 
     @alpha.view(model=AlphaRoot)
-    def alpha_default(self, request):
+    def alpha_default(self: AlphaRoot, request: morepath.Request[alpha]) -> str:
         return request.app.one()
 
     @beta.view(model=Root)
-    def default(self, request):
+    def default(self: Root, request: morepath.Request[beta]) -> str:
         return f"View for {self.id}, message: {request.app.one()}"
 
     c = Client(alpha())

--- a/morepath/tests/test_model.py
+++ b/morepath/tests/test_model.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+from typing import Any
 from urllib.parse import urlencode
 
 import webob
@@ -8,7 +11,9 @@ from morepath.converter import IDENTITY_CONVERTER, Converter, ConverterRegistry
 from morepath.path import get_arguments
 
 
-def consume(mount, path, parameters=None):
+def consume(
+    mount: morepath.App, path: str, parameters: Any = None
+) -> tuple[Any, morepath.Request]:
     if parameters:
         path += "?" + urlencode(parameters, True)
     request = mount.request(webob.Request.blank(path).environ)
@@ -20,16 +25,17 @@ class Root:
 
 
 class Model:
-    pass
+    id: str
+    param: str
 
 
-def test_register_path():
+def test_register_path() -> None:
     class App(morepath.App):
         pass
 
     root = Root()
 
-    def get_model(id):
+    def get_model(id: str) -> Model:
         model = Model()
         model.id = id
         return model
@@ -61,18 +67,18 @@ def test_register_path():
     model.id = "b"
 
     info = app._get_path(model)
-
+    assert info is not None
     assert info.path == "b"
     assert info.parameters == {}
 
 
-def test_register_path_with_parameters():
+def test_register_path_with_parameters() -> None:
     class App(morepath.App):
         pass
 
     root = Root()
 
-    def get_model(id, param="default"):
+    def get_model(id: str, param: str = "default") -> Model:
         model = Model()
         model.id = id
         model.param = param
@@ -112,18 +118,18 @@ def test_register_path_with_parameters():
     model.param = "other"
 
     info = mount._get_path(model)
-
+    assert info is not None
     assert info.path == "b"
     assert info.parameters == {"param": ["other"]}
 
 
-def test_traject_path_with_leading_slash():
+def test_traject_path_with_leading_slash() -> None:
     class App(morepath.App):
         pass
 
     root = Root()
 
-    def get_model(id):
+    def get_model(id: str) -> Model:
         model = Model()
         model.id = id
         return model
@@ -154,28 +160,28 @@ def test_traject_path_with_leading_slash():
     assert obj.id == "a"
 
 
-def test_get_arguments():
-    def foo(a, b):
+def test_get_arguments() -> None:
+    def foo(a: int, b: int) -> None:
         pass
 
     assert get_arguments(foo, []) == {"a": None, "b": None}
 
 
-def test_get_arguments_defaults():
-    def foo(a, b=1):
+def test_get_arguments_defaults() -> None:
+    def foo(a: int, b: int = 1) -> None:
         pass
 
     assert get_arguments(foo, []) == {"a": None, "b": 1}
 
 
-def test_get_arguments_exclude():
-    def foo(a, b, request):
+def test_get_arguments_exclude() -> None:
+    def foo(a: int, b: int, request: morepath.Request) -> None:
         pass
 
     assert get_arguments(foo, ["request"]) == {"a": None, "b": None}
 
 
-def test_argument_and_explicit_converters_none_defaults():
+def test_argument_and_explicit_converters_none_defaults() -> None:
     reg = ConverterRegistry()
 
     assert reg.argument_and_explicit_converters({"a": None}, {}) == {
@@ -183,7 +189,7 @@ def test_argument_and_explicit_converters_none_defaults():
     }
 
 
-def test_argument_and_explicit_converters_explicit():
+def test_argument_and_explicit_converters_explicit() -> None:
     reg = ConverterRegistry()
 
     assert reg.argument_and_explicit_converters(
@@ -191,7 +197,7 @@ def test_argument_and_explicit_converters_explicit():
     ) == {"a": Converter(int)}
 
 
-def test_argument_and_explicit_converters_from_type():
+def test_argument_and_explicit_converters_from_type() -> None:
 
     reg = ConverterRegistry()
     reg.register_converter(int, Converter(int))

--- a/morepath/tests/test_mount_directive.py
+++ b/morepath/tests/test_mount_directive.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 import pytest
 from webtest import TestApp as Client
 
@@ -5,7 +9,7 @@ import morepath
 from morepath.error import ConflictError, LinkError
 
 
-def test_model_mount_conflict():
+def test_model_mount_conflict() -> None:
     class app(morepath.App):
         pass
 
@@ -16,23 +20,23 @@ def test_model_mount_conflict():
         pass
 
     @app.path(model=A, path="a")
-    def get_a():
+    def get_a() -> A:
         return A()
 
     @app.mount(app=app2, path="a")
-    def get_mount():
+    def get_mount() -> app2:
         return app2()
 
     with pytest.raises(ConflictError):
         app.commit()
 
 
-def test_mount_basic():
+def test_mount_basic() -> None:
     class app(morepath.App):
         pass
 
     class mounted(morepath.App):
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @mounted.path(path="")
@@ -40,15 +44,15 @@ def test_mount_basic():
         pass
 
     @mounted.view(model=MountedRoot)
-    def root_default(self, request):
+    def root_default(self: MountedRoot, request: morepath.Request) -> str:
         return "The root"
 
     @mounted.view(model=MountedRoot, name="link")
-    def root_link(self, request):
+    def root_link(self: MountedRoot, request: morepath.Request) -> str:
         return request.link(self)
 
     @app.mount(path="{id}", app=mounted)
-    def get_mounted(id):
+    def get_mounted(id: str) -> mounted:
         return mounted(id=id)
 
     c = Client(app())
@@ -60,23 +64,23 @@ def test_mount_basic():
     assert response.body == b"http://localhost/foo"
 
 
-def test_mounted_app_classes():
+def test_mounted_app_classes() -> None:
     class App(morepath.App):
         pass
 
     class Mounted(morepath.App):
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     class Sub(morepath.App):
         pass
 
     @App.mount(path="{id}", app=Mounted)
-    def get_mounted(id):
+    def get_mounted(id: str) -> Mounted:
         return Mounted(id=id)
 
     @Mounted.mount(path="sub", app=Sub)
-    def get_sub():
+    def get_sub() -> Sub:
         return Sub()
 
     assert App.commit() == {App, Mounted, Sub}
@@ -84,7 +88,7 @@ def test_mounted_app_classes():
     assert App.mounted_app_classes() == {App, Mounted, Sub}
 
 
-def test_mounted_app_classes_nothing_mounted():
+def test_mounted_app_classes_nothing_mounted() -> None:
     class App(morepath.App):
         pass
 
@@ -93,7 +97,7 @@ def test_mounted_app_classes_nothing_mounted():
     assert App.mounted_app_classes() == {App}
 
 
-def test_mount_none_should_fail():
+def test_mount_none_should_fail() -> None:
     class app(morepath.App):
         pass
 
@@ -105,15 +109,15 @@ def test_mount_none_should_fail():
         pass
 
     @mounted.view(model=MountedRoot)
-    def root_default(self, request):
+    def root_default(self: MountedRoot, request: morepath.Request) -> str:
         return "The root"
 
     @mounted.view(model=MountedRoot, name="link")
-    def root_link(self, request):
+    def root_link(self: MountedRoot, request: morepath.Request) -> str:
         return request.link(self)
 
     @app.mount(path="{id}", app=mounted)
-    def mount_mounted(id):
+    def mount_mounted(id: str) -> None:
         return None
 
     c = Client(app())
@@ -122,25 +126,25 @@ def test_mount_none_should_fail():
     c.get("/foo/link", status=404)
 
 
-def test_mount_context():
+def test_mount_context() -> None:
     class app(morepath.App):
         pass
 
     class mounted(morepath.App):
-        def __init__(self, mount_id):
+        def __init__(self, mount_id: str) -> None:
             self.mount_id = mount_id
 
     @mounted.path(path="")
     class MountedRoot:
-        def __init__(self, app):
+        def __init__(self, app: mounted) -> None:
             self.mount_id = app.mount_id
 
     @mounted.view(model=MountedRoot)
-    def root_default(self, request):
+    def root_default(self: MountedRoot, request: morepath.Request) -> str:
         return "The root for mount id: %s" % self.mount_id
 
     @app.mount(path="{id}", app=mounted)
-    def get_context(id):
+    def get_context(id: str) -> mounted:
         return mounted(mount_id=id)
 
     c = Client(app())
@@ -151,26 +155,26 @@ def test_mount_context():
     assert response.body == b"The root for mount id: bar"
 
 
-def test_mount_context_parameters():
+def test_mount_context_parameters() -> None:
     class app(morepath.App):
         pass
 
     class mounted(morepath.App):
-        def __init__(self, mount_id):
+        def __init__(self, mount_id: int) -> None:
             self.mount_id = mount_id
 
     @mounted.path(path="")
     class MountedRoot:
-        def __init__(self, app):
+        def __init__(self, app: mounted) -> None:
             assert isinstance(app.mount_id, int)
             self.mount_id = app.mount_id
 
     @mounted.view(model=MountedRoot)
-    def root_default(self, request):
+    def root_default(self: MountedRoot, request: morepath.Request) -> str:
         return "The root for mount id: %s" % self.mount_id
 
     @app.mount(path="mounts", app=mounted)
-    def get_context(mount_id=0):
+    def get_context(mount_id: int = 0) -> mounted:
         return mounted(mount_id=mount_id)
 
     c = Client(app())
@@ -181,29 +185,29 @@ def test_mount_context_parameters():
     assert response.body == b"The root for mount id: 0"
 
 
-def test_mount_context_parameters_override_default():
+def test_mount_context_parameters_override_default() -> None:
     class app(morepath.App):
         pass
 
     class mounted(morepath.App):
-        def __init__(self, mount_id):
+        def __init__(self, mount_id: str) -> None:
             self.mount_id = mount_id
 
     @mounted.path(path="")
     class MountedRoot:
-        def __init__(self, app, mount_id):
+        def __init__(self, app: mounted, mount_id: str) -> None:
             self.mount_id = mount_id
             self.app_mount_id = app.mount_id
 
     @mounted.view(model=MountedRoot)
-    def root_default(self, request):
+    def root_default(self: MountedRoot, request: morepath.Request) -> str:
         return "mount_id: {} app_mount_id: {}".format(
             self.mount_id,
             self.app_mount_id,
         )
 
     @app.mount(path="{id}", app=mounted)
-    def get_context(id):
+    def get_context(id: str) -> mounted:
         return mounted(mount_id=id)
 
     c = Client(app())
@@ -216,18 +220,18 @@ def test_mount_context_parameters_override_default():
     assert response.body == b"mount_id: blah app_mount_id: bar"
 
 
-def test_mount_context_standalone():
+def test_mount_context_standalone() -> None:
     class app(morepath.App):
-        def __init__(self, mount_id):
+        def __init__(self, mount_id: str) -> None:
             self.mount_id = mount_id
 
     @app.path(path="")
     class Root:
-        def __init__(self, app):
+        def __init__(self, app: app) -> None:
             self.mount_id = app.mount_id
 
     @app.view(model=Root)
-    def root_default(self, request):
+    def root_default(self: Root, request: morepath.Request) -> str:
         return "The root for mount id: %s" % self.mount_id
 
     c = Client(app(mount_id="foo"))
@@ -236,30 +240,31 @@ def test_mount_context_standalone():
     assert response.body == b"The root for mount id: foo"
 
 
-def test_mount_parent_link():
+def test_mount_parent_link() -> None:
     class app(morepath.App):
         pass
 
     @app.path(path="models/{id}")
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     class mounted(morepath.App):
-        def __init__(self, mount_id):
+        def __init__(self, mount_id: str) -> None:
             self.mount_id = mount_id
 
     @mounted.path(path="")
     class MountedRoot:
-        def __init__(self, mount_id):
+        def __init__(self, mount_id: str) -> None:
             self.mount_id = mount_id
 
     @mounted.view(model=MountedRoot)
-    def root_default(self, request):
+    def root_default(self: MountedRoot, request: morepath.Request) -> str:
+        assert request.app.parent is not None
         return request.link(Model("one"), app=request.app.parent)
 
     @app.mount(path="{id}", app=mounted)
-    def get_context(id):
+    def get_context(id: str) -> mounted:
         return mounted(mount_id=id)
 
     c = Client(app())
@@ -268,17 +273,17 @@ def test_mount_parent_link():
     assert response.body == b"http://localhost/models/one"
 
 
-def test_mount_child_link():
+def test_mount_child_link() -> None:
     class app(morepath.App):
         pass
 
     class mounted(morepath.App):
-        def __init__(self, mount_id):
+        def __init__(self, mount_id: str) -> None:
             self.mount_id = mount_id
 
     @mounted.path(path="models/{id}")
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @app.path(path="")
@@ -286,17 +291,19 @@ def test_mount_child_link():
         pass
 
     @app.view(model=Root)
-    def app_root_default(self, request):
+    def app_root_default(self: Root, request: morepath.Request) -> str:
         child = request.app.child(mounted, id="foo")
+        assert child is not None
         return request.link(Model("one"), app=child)
 
     @app.view(model=Root, name="inst")
-    def app_root_inst(self, request):
+    def app_root_inst(self: Root, request: morepath.Request) -> str:
         child = request.app.child(mounted(mount_id="foo"))
+        assert child is not None
         return request.link(Model("one"), app=child)
 
     @app.mount(path="{id}", app=mounted, variables=lambda a: {"id": a.mount_id})
-    def get_context(id):
+    def get_context(id: str) -> mounted:
         return mounted(mount_id=id)
 
     c = Client(app())
@@ -307,7 +314,7 @@ def test_mount_child_link():
     assert response.body == b"http://localhost/foo/models/one"
 
 
-def test_mount_sibling_link():
+def test_mount_sibling_link() -> None:
     class app(morepath.App):
         pass
 
@@ -319,17 +326,18 @@ def test_mount_sibling_link():
 
     @first.path(path="models/{id}")
     class FirstModel:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @first.view(model=FirstModel)
-    def first_model_default(self, request):
+    def first_model_default(self: FirstModel, request: morepath.Request) -> str:
         sibling = request.app.sibling("second")
+        assert sibling is not None
         return request.link(SecondModel(2), app=sibling)
 
     @second.path(path="foos/{id}")
     class SecondModel:
-        def __init__(self, id):
+        def __init__(self, id: int) -> None:
             self.id = id
 
     @app.path(path="")
@@ -337,11 +345,11 @@ def test_mount_sibling_link():
         pass
 
     @app.mount(path="first", app=first)
-    def get_context_first():
+    def get_context_first() -> first:
         return first()
 
     @app.mount(path="second", app=second)
-    def get_context_second():
+    def get_context_second() -> second:
         return second()
 
     c = Client(app())
@@ -350,7 +358,7 @@ def test_mount_sibling_link():
     assert response.body == b"http://localhost/second/foos/2"
 
 
-def test_mount_sibling_link_at_root_app():
+def test_mount_sibling_link_at_root_app() -> None:
     class app(morepath.App):
         pass
 
@@ -359,13 +367,12 @@ def test_mount_sibling_link_at_root_app():
         pass
 
     class Item:
-        def __init__(self, id):
+        def __init__(self, id: int) -> None:
             self.id = id
 
     @app.view(model=Root)
-    def root_default(self, request):
-        sibling = request.app.sibling("foo")
-        return request.link(Item(3), app=sibling)
+    def root_default(self: Root, request: morepath.Request) -> str:
+        return request.link(Item(3), app=request.app.sibling("foo"))  # type: ignore
 
     c = Client(app())
 
@@ -373,17 +380,17 @@ def test_mount_sibling_link_at_root_app():
         c.get("/")
 
 
-def test_mount_child_link_unknown_child():
+def test_mount_child_link_unknown_child() -> None:
     class app(morepath.App):
         pass
 
     class mounted(morepath.App):
-        def __init__(self, mount_id):
+        def __init__(self, mount_id: str) -> None:
             self.mount_id = mount_id
 
     @mounted.path(path="models/{id}")
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @app.path(path="")
@@ -391,14 +398,14 @@ def test_mount_child_link_unknown_child():
         pass
 
     @app.view(model=Root)
-    def app_root_default(self, request):
+    def app_root_default(self: Root, request: morepath.Request) -> str:
         child = request.app.child(mounted, id="foo")
         if child is None:
             return "link error"
         return request.link(Model("one"), app=child)
 
     @app.view(model=Root, name="inst")
-    def app_root_inst(self, request):
+    def app_root_inst(self: Root, request: morepath.Request) -> str:
         child = request.app.child(mounted(mount_id="foo"))
         if child is None:
             return "link error"
@@ -414,12 +421,12 @@ def test_mount_child_link_unknown_child():
     assert response.body == b"link error"
 
 
-def test_mount_child_link_unknown_parent():
+def test_mount_child_link_unknown_parent() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @app.path(path="")
@@ -427,7 +434,7 @@ def test_mount_child_link_unknown_parent():
         pass
 
     @app.view(model=Root)
-    def app_root_default(self, request):
+    def app_root_default(self: Root, request: morepath.Request) -> str:
         parent = request.app.parent
         if parent is None:
             return "link error"
@@ -439,17 +446,17 @@ def test_mount_child_link_unknown_parent():
     assert response.body == b"link error"
 
 
-def test_mount_child_link_unknown_app():
+def test_mount_child_link_unknown_app() -> None:
     class app(morepath.App):
         pass
 
     class mounted(morepath.App):
-        def __init__(self, mount_id):
+        def __init__(self, mount_id: str) -> None:
             self.mount_id = mount_id
 
     @mounted.path(path="models/{id}")
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @app.path(path="")
@@ -457,10 +464,10 @@ def test_mount_child_link_unknown_app():
         pass
 
     @app.view(model=Root)
-    def app_root_default(self, request):
+    def app_root_default(self: Root, request: morepath.Request) -> str:
         child = request.app.child(mounted, id="foo")
         try:
-            return request.link(Model("one"), app=child)
+            return request.link(Model("one"), app=child)  # type: ignore
         except LinkError:
             return "link error"
 
@@ -472,18 +479,18 @@ def test_mount_child_link_unknown_app():
     assert response.body == b"link error"
 
 
-def test_mount_link_prefix():
+def test_mount_link_prefix() -> None:
     class App(morepath.App):
         pass
 
     class Mounted(morepath.App):
-        def __init__(self, mount_id):
+        def __init__(self, mount_id: str) -> None:
             self.mount_id = mount_id
 
     @App.mount(
         path="/mnt/{id}", app=Mounted, variables=lambda a: dict(id=a.mount_id)
     )
-    def get_mounted(id):
+    def get_mounted(id: str) -> Mounted:
         return Mounted(mount_id=id)
 
     @App.path(path="")
@@ -495,24 +502,29 @@ def test_mount_link_prefix():
         pass
 
     @App.link_prefix()
-    def link_prefix(request):
+    def link_prefix(request: morepath.Request) -> str:
         return "http://app"
 
     @Mounted.link_prefix()
-    def mounted_link_prefix(request):
+    def mounted_link_prefix(request: morepath.Request) -> str:
         return "http://mounted"
 
     @App.view(model=AppRoot, name="get-root-link")
-    def get_root_link(self, request):
+    def get_root_link(self: AppRoot, request: morepath.Request) -> str:
         return request.link(self)
 
     @Mounted.view(model=MountedRoot, name="get-mounted-root-link")
-    def get_mounted_root_link(self, request):
+    def get_mounted_root_link(
+        self: MountedRoot, request: morepath.Request
+    ) -> str:
         return request.link(self)
 
     @Mounted.view(model=MountedRoot, name="get-root-link-through-mount")
-    def get_root_link_through_mount(self, request):
+    def get_root_link_through_mount(
+        self: MountedRoot, request: morepath.Request
+    ) -> Any:
         parent = request.app.parent
+        assert parent is not None
         return request.view(AppRoot(), app=parent, name="get-root-link")
 
     c = Client(App())
@@ -530,12 +542,12 @@ def test_mount_link_prefix():
     assert response.body == b"http://app/"
 
 
-def test_request_view_in_mount():
+def test_request_view_in_mount() -> None:
     class app(morepath.App):
         pass
 
     class mounted(morepath.App):
-        def __init__(self, mount_id):
+        def __init__(self, mount_id: str) -> None:
             self.mount_id = mount_id
 
     @app.path(path="")
@@ -544,27 +556,33 @@ def test_request_view_in_mount():
 
     @mounted.path(path="models/{id}")
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @mounted.view(model=Model)
-    def model_default(self, request):
+    def model_default(self: Model, request: morepath.Request) -> dict[str, str]:
         return {"hey": "Hey"}
 
     @app.view(model=Root)
-    def root_default(self, request):
+    def root_default(self: Root, request: morepath.Request) -> Any:
         child = request.app.child(mounted, id="foo")
-        return request.view(Model("x"), app=child)["hey"]
+        assert child is not None
+        result = request.view(Model("x"), app=child)
+        assert result is not None
+        return result["hey"]
 
     @app.view(model=Root, name="inst")
-    def root_inst(self, request):
+    def root_inst(self: Root, request: morepath.Request) -> Any:
         child = request.app.child(mounted(mount_id="foo"))
-        return request.view(Model("x"), app=child)["hey"]
+        assert child is not None
+        result = request.view(Model("x"), app=child)
+        assert result is not None
+        return result["hey"]
 
     @app.mount(
         path="{id}", app=mounted, variables=lambda a: dict(id=a.mount_id)
     )
-    def get_context(id):
+    def get_context(id: str) -> mounted:
         return mounted(mount_id=id)
 
     c = Client(app())
@@ -576,12 +594,12 @@ def test_request_view_in_mount():
     assert response.body == b"Hey"
 
 
-def test_request_link_child_child():
+def test_request_link_child_child() -> None:
     class app(morepath.App):
         pass
 
     class mounted(morepath.App):
-        def __init__(self, mount_id):
+        def __init__(self, mount_id: str) -> None:
             self.mount_id = mount_id
 
     class submounted(morepath.App):
@@ -592,27 +610,33 @@ def test_request_link_child_child():
         pass
 
     @app.view(model=Root)
-    def root_default(self, request):
-        child = request.app.child(mounted, id="foo").child(submounted)
+    def root_default(self: Root, request: morepath.Request) -> Any:
+        child: morepath.App | None = request.app.child(mounted, id="foo")
+        assert child is not None
+        child = child.child(submounted)
+        assert child is not None
         return request.view(SubRoot(), app=child)
 
     @app.view(model=Root, name="inst")
-    def root_inst(self, request):
-        child = request.app.child(mounted(mount_id="foo")).child(submounted())
+    def root_inst(self: Root, request: morepath.Request) -> Any:
+        child: morepath.App | None = request.app.child(mounted(mount_id="foo"))
+        assert child is not None
+        child = child.child(submounted())
+        assert child is not None
         return request.view(SubRoot(), app=child)
 
     @app.view(model=Root, name="info")
-    def root_info(self, request):
+    def root_info(self: Root, request: morepath.Request) -> str:
         return "info"
 
     @app.mount(
         path="{id}", app=mounted, variables=lambda a: dict(mount_id=a.mount_id)
     )
-    def get_context(id):
+    def get_context(id: str) -> mounted:
         return mounted(mount_id=id)
 
     @mounted.mount(path="sub", app=submounted)
-    def get_context2():
+    def get_context2() -> submounted:
         return submounted()
 
     @submounted.path(path="")
@@ -620,12 +644,15 @@ def test_request_link_child_child():
         pass
 
     @submounted.view(model=SubRoot)
-    def subroot_default(self, request):
+    def subroot_default(self: SubRoot, request: morepath.Request) -> str:
         return "SubRoot"
 
     @submounted.view(model=SubRoot, name="parentage")
-    def subroot_parentage(self, request):
-        ancestor = request.app.parent.parent
+    def subroot_parentage(self: SubRoot, request: morepath.Request) -> Any:
+        parent = request.app.parent
+        assert parent is not None
+        ancestor = parent.parent
+        assert ancestor is not None
         return request.view(Root(), name="info", app=ancestor)
 
     c = Client(app())
@@ -639,12 +666,12 @@ def test_request_link_child_child():
     assert response.body == b"info"
 
 
-def test_request_view_in_mount_broken():
+def test_request_view_in_mount_broken() -> None:
     class app(morepath.App):
         pass
 
     class mounted(morepath.App):
-        def __init__(self, mount_id):
+        def __init__(self, mount_id: str) -> None:
             self.mount_id = mount_id
 
     @app.path(path="")
@@ -653,42 +680,46 @@ def test_request_view_in_mount_broken():
 
     @mounted.path(path="models/{id}")
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @mounted.view(model=Model)
-    def model_default(self, request):
+    def model_default(self: Model, request: morepath.Request) -> dict[str, str]:
         return {"hey": "Hey"}
 
     @app.view(model=Root)
-    def root_default(self, request):
+    def root_default(self: Root, request: morepath.Request) -> Any:
         child = request.app.child(mounted, id="foo")
         try:
-            return request.view(Model("x"), app=child)["hey"]
+            return request.view(Model("x"), app=child)["hey"]  # type: ignore
         except LinkError:
             return "link error"
 
     @app.view(model=Root, name="inst")
-    def root_inst(self, request):
+    def root_inst(self: Root, request: morepath.Request) -> Any:
         child = request.app.child(mounted(mount_id="foo"))
         try:
-            return request.view(Model("x"), app=child)["hey"]
+            return request.view(Model("x"), app=child)["hey"]  # type: ignore
         except LinkError:
             return "link error"
 
     @app.view(model=Root, name="doublechild")
-    def doublechild(self, request):
+    def doublechild(self: Root, request: morepath.Request) -> str | None:
         try:
-            request.app.child(mounted, id="foo").child(mounted, id="bar")
+            request.app.child(mounted, id="foo").child(mounted, id="bar")  # type: ignore
         except AttributeError:
             return "link error"
+        else:
+            return None
 
     @app.view(model=Root, name="childparent")
-    def childparent(self, request):
+    def childparent(self: Root, request: morepath.Request) -> str | None:
         try:
-            request.app.child(mounted, id="foo").parent
+            request.app.child(mounted, id="foo").parent  # type: ignore
         except AttributeError:
             return "link error"
+        else:
+            return None
 
     # deliberately don't mount so using view is broken
 
@@ -707,28 +738,28 @@ def test_request_view_in_mount_broken():
     assert response.body == b"link error"
 
 
-def test_mount_implicit_converters():
+def test_mount_implicit_converters() -> None:
     class app(morepath.App):
         pass
 
     class mounted(morepath.App):
-        def __init__(self, id):
+        def __init__(self, id: int) -> None:
             self.id = id
 
     class MountedRoot:
-        def __init__(self, id):
+        def __init__(self, id: int) -> None:
             self.id = id
 
     @mounted.path(path="", model=MountedRoot)
-    def get_root(app):
+    def get_root(app: mounted) -> MountedRoot:
         return MountedRoot(app.id)
 
     @mounted.view(model=MountedRoot)
-    def root_default(self, request):
+    def root_default(self: MountedRoot, request: morepath.Request) -> str:
         return f"The root for: {self.id} {type(self.id)}"
 
     @app.mount(path="{id}", app=mounted)
-    def get_context(id=0):
+    def get_context(id: int = 0) -> mounted:
         return mounted(id=id)
 
     c = Client(app())
@@ -740,28 +771,28 @@ def test_mount_implicit_converters():
     )
 
 
-def test_mount_explicit_converters():
+def test_mount_explicit_converters() -> None:
     class app(morepath.App):
         pass
 
     class mounted(morepath.App):
-        def __init__(self, id):
+        def __init__(self, id: int) -> None:
             self.id = id
 
     class MountedRoot:
-        def __init__(self, id):
+        def __init__(self, id: int) -> None:
             self.id = id
 
     @mounted.path(path="", model=MountedRoot)
-    def get_root(app):
+    def get_root(app: mounted) -> MountedRoot:
         return MountedRoot(id=app.id)
 
     @mounted.view(model=MountedRoot)
-    def root_default(self, request):
+    def root_default(self: MountedRoot, request: morepath.Request) -> str:
         return f"The root for: {self.id} {type(self.id)}"
 
     @app.mount(path="{id}", app=mounted, converters=dict(id=int))
-    def get_context(id):
+    def get_context(id: int) -> mounted:
         return mounted(id=id)
 
     c = Client(app())
@@ -773,7 +804,7 @@ def test_mount_explicit_converters():
     )
 
 
-def test_mount_view_in_child_view():
+def test_mount_view_in_child_view() -> None:
     class app(morepath.App):
         pass
 
@@ -785,23 +816,27 @@ def test_mount_view_in_child_view():
         pass
 
     @app.view(model=Root)
-    def default_homepage(self, request):
-        return request.view(FooRoot(), app=request.app.child(fooapp))
+    def default_homepage(self: Root, request: morepath.Request) -> Any:
+        child = request.app.child(fooapp)
+        assert child is not None
+        return request.view(FooRoot(), app=child)
 
     @fooapp.path(path="")
     class FooRoot:
         pass
 
     @fooapp.view(model=FooRoot, name="name")
-    def foo_name(self, request):
+    def foo_name(self: FooRoot, request: morepath.Request) -> str:
         return "Foo"
 
     @fooapp.view(model=FooRoot)
-    def foo_default(self, request):
-        return "Hello " + request.view(self, name="name")
+    def foo_default(self: FooRoot, request: morepath.Request) -> str:
+        result = request.view(self, name="name")
+        assert isinstance(result, str)
+        return "Hello " + result
 
     @app.mount(path="foo", app=fooapp)
-    def mount_to_root():
+    def mount_to_root() -> fooapp:
         return fooapp()
 
     c = Client(app())
@@ -813,7 +848,7 @@ def test_mount_view_in_child_view():
     assert response.body == b"Hello Foo"
 
 
-def test_mount_view_in_child_view_then_parent_view():
+def test_mount_view_in_child_view_then_parent_view() -> None:
     class app(morepath.App):
         pass
 
@@ -825,16 +860,16 @@ def test_mount_view_in_child_view_then_parent_view():
         pass
 
     @app.view(model=Root)
-    def default_homepage(self, request):
+    def default_homepage(self: Root, request: morepath.Request) -> str:
         other = request.app.child(fooapp)
-        return (
-            request.view(FooRoot(), app=other)
-            + " "
-            + request.view(self, name="other")
+        assert other is not None
+        return "{} {}".format(
+            request.view(FooRoot(), app=other),
+            request.view(self, name="other"),
         )
 
     @app.view(model=Root, name="other")
-    def root_other(self, request):
+    def root_other(self: Root, request: morepath.Request) -> str:
         return "other"
 
     @fooapp.path(path="")
@@ -842,15 +877,15 @@ def test_mount_view_in_child_view_then_parent_view():
         pass
 
     @fooapp.view(model=FooRoot, name="name")
-    def foo_name(self, request):
+    def foo_name(self: FooRoot, request: morepath.Request) -> str:
         return "Foo"
 
     @fooapp.view(model=FooRoot)
-    def foo_default(self, request):
-        return "Hello " + request.view(self, name="name")
+    def foo_default(self: FooRoot, request: morepath.Request) -> str:
+        return "Hello {}".format(request.view(self, name="name"))
 
     @app.mount(path="foo", app=fooapp)
-    def mount_to_root():
+    def mount_to_root() -> fooapp:
         return fooapp()
 
     c = Client(app())
@@ -859,7 +894,7 @@ def test_mount_view_in_child_view_then_parent_view():
     assert response.body == b"Hello Foo other"
 
 
-def test_mount_directive_with_link_and_absorb():
+def test_mount_directive_with_link_and_absorb() -> None:
     class app1(morepath.App):
         pass
 
@@ -871,19 +906,19 @@ def test_mount_directive_with_link_and_absorb():
         pass
 
     class Model2:
-        def __init__(self, absorb):
+        def __init__(self, absorb: str) -> None:
             self.absorb = absorb
 
     @app2.path(model=Model2, path="", absorb=True)
-    def get_model(absorb):
+    def get_model(absorb: str) -> Model2:
         return Model2(absorb)
 
     @app2.view(model=Model2)
-    def default(self, request):
+    def default(self: Model2, request: morepath.Request) -> str:
         return f"A:{self.absorb} L:{request.link(self)}"
 
     @app1.mount(path="foo", app=app2)
-    def get_mount():
+    def get_mount() -> app2:
         return app2()
 
     c = Client(app1())
@@ -895,7 +930,7 @@ def test_mount_directive_with_link_and_absorb():
     assert response.body == b"A:bla L:http://localhost/foo/bla"
 
 
-def test_mount_named_child_link_explicit_name():
+def test_mount_named_child_link_explicit_name() -> None:
     class app(morepath.App):
         pass
 
@@ -904,7 +939,7 @@ def test_mount_named_child_link_explicit_name():
 
     @mounted.path(path="models/{id}")
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str):
             self.id = id
 
     @app.path(path="")
@@ -912,15 +947,19 @@ def test_mount_named_child_link_explicit_name():
         pass
 
     @app.view(model=Root)
-    def app_root_default(self, request):
-        return request.link(Model("one"), app=request.app.child(mounted))
+    def app_root_default(self: Root, request: morepath.Request) -> str:
+        child = request.app.child(mounted)
+        assert child is not None
+        return request.link(Model("one"), app=child)
 
     @app.view(model=Root, name="extra")
-    def app_root_default2(self, request):
-        return request.link(Model("one"), app=request.app.child("sub"))
+    def app_root_default2(self: Root, request: morepath.Request) -> str:
+        child = request.app.child("sub")
+        assert child is not None
+        return request.link(Model("one"), app=child)
 
     @app.mount(path="subapp", app=mounted, name="sub")
-    def get_context():
+    def get_context() -> mounted:
         return mounted()
 
     c = Client(app())
@@ -932,7 +971,7 @@ def test_mount_named_child_link_explicit_name():
     assert response.body == b"http://localhost/subapp/models/one"
 
 
-def test_mount_named_child_link_name_defaults_to_path():
+def test_mount_named_child_link_name_defaults_to_path() -> None:
     class app(morepath.App):
         pass
 
@@ -941,7 +980,7 @@ def test_mount_named_child_link_name_defaults_to_path():
 
     @mounted.path(path="models/{id}")
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @app.path(path="")
@@ -949,15 +988,19 @@ def test_mount_named_child_link_name_defaults_to_path():
         pass
 
     @app.view(model=Root)
-    def app_root_default(self, request):
-        return request.link(Model("one"), app=request.app.child(mounted))
+    def app_root_default(self: Root, request: morepath.Request) -> str:
+        child = request.app.child(mounted)
+        assert child is not None
+        return request.link(Model("one"), app=child)
 
     @app.view(model=Root, name="extra")
-    def app_root_default2(self, request):
-        return request.link(Model("one"), app=request.app.child("subapp"))
+    def app_root_default2(self: Root, request: morepath.Request) -> str:
+        child = request.app.child("subapp")
+        assert child is not None
+        return request.link(Model("one"), app=child)
 
     @app.mount(path="subapp", app=mounted)
-    def get_context():
+    def get_context() -> mounted:
         return mounted()
 
     c = Client(app())
@@ -969,12 +1012,12 @@ def test_mount_named_child_link_name_defaults_to_path():
     assert response.body == b"http://localhost/subapp/models/one"
 
 
-def test_named_mount_with_parameters():
+def test_named_mount_with_parameters() -> None:
     class app(morepath.App):
         pass
 
     class mounted(morepath.App):
-        def __init__(self, mount_id):
+        def __init__(self, mount_id: int) -> None:
             self.mount_id = mount_id
 
     @app.path(path="")
@@ -983,29 +1026,30 @@ def test_named_mount_with_parameters():
 
     @mounted.path(path="")
     class MountedRoot:
-        def __init__(self, mount_id):
+        def __init__(self, mount_id: int) -> None:
             assert isinstance(mount_id, int)
             self.mount_id = mount_id
 
     @mounted.view(model=MountedRoot)
-    def root_default(self, request):
+    def root_default(self: MountedRoot, request: morepath.Request) -> str:
         return "The root for mount id: %s" % self.mount_id
 
     @app.mount(path="mounts/{mount_id}", app=mounted)
-    def get_context(mount_id=0):
+    def get_context(mount_id: int = 0) -> mounted:
         return mounted(mount_id=mount_id)
 
     class Item:
-        def __init__(self, id):
+        def __init__(self, id: str | int) -> None:
             self.id = id
 
     @mounted.path(path="items/{id}", model=Item)
-    def get_item(id):
+    def get_item(id: str) -> Item:
         return Item(id)
 
     @app.view(model=Root)
-    def root_default2(self, request):
+    def root_default2(self: Root, request: morepath.Request) -> str:
         child = request.app.child("mounts/{mount_id}", mount_id=3)
+        assert child is not None
         return request.link(Item(4), app=child)
 
     c = Client(app())
@@ -1014,12 +1058,12 @@ def test_named_mount_with_parameters():
     assert response.body == b"http://localhost/mounts/3/items/4"
 
 
-def test_named_mount_with_url_parameters():
+def test_named_mount_with_url_parameters() -> None:
     class app(morepath.App):
         pass
 
     class mounted(morepath.App):
-        def __init__(self, mount_id):
+        def __init__(self, mount_id: int) -> None:
             self.mount_id = mount_id
 
     @app.path(path="")
@@ -1028,29 +1072,30 @@ def test_named_mount_with_url_parameters():
 
     @mounted.path(path="")
     class MountedRoot:
-        def __init__(self, mount_id):
+        def __init__(self, mount_id: int) -> None:
             assert isinstance(mount_id, int)
             self.mount_id = mount_id
 
     @mounted.view(model=MountedRoot)
-    def root_default(self, request):
+    def root_default(self: MountedRoot, request: morepath.Request) -> str:
         return "The root for mount id: %s" % self.mount_id
 
     @app.mount(path="mounts", app=mounted)
-    def get_context(mount_id=0):
+    def get_context(mount_id: int = 0) -> mounted:
         return mounted(mount_id=mount_id)
 
     class Item:
-        def __init__(self, id):
+        def __init__(self, id: str | int) -> None:
             self.id = id
 
     @mounted.path(path="items/{id}", model=Item)
-    def get_item(id):
+    def get_item(id: str) -> Item:
         return Item(id)
 
     @app.view(model=Root)
-    def root_default2(self, request):
+    def root_default2(self: Root, request: morepath.Request) -> str:
         child = request.app.child("mounts", mount_id=3)
+        assert child is not None
         return request.link(Item(4), app=child)
 
     c = Client(app())
@@ -1059,12 +1104,12 @@ def test_named_mount_with_url_parameters():
     assert response.body == b"http://localhost/mounts/items/4?mount_id=3"
 
 
-def test_access_app_through_request():
+def test_access_app_through_request() -> None:
     class root(morepath.App):
         pass
 
     class sub(morepath.App):
-        def __init__(self, name):
+        def __init__(self, name: str) -> None:
             self.name = name
 
     @root.path(path="")
@@ -1072,22 +1117,23 @@ def test_access_app_through_request():
         pass
 
     @root.view(model=RootModel)
-    def root_model_default(self, request):
+    def root_model_default(self: RootModel, request: morepath.Request) -> str:
         child = request.app.child(sub, mount_name="foo")
+        assert child is not None
         return request.link(SubModel("foo"), app=child)
 
     class SubModel:
-        def __init__(self, name):
+        def __init__(self, name: str) -> None:
             self.name = name
 
     @sub.path(path="", model=SubModel)
-    def get_sub_model(request):
+    def get_sub_model(request: morepath.Request[sub]) -> SubModel:
         return SubModel(request.app.name)
 
     @root.mount(
         app=sub, path="{mount_name}", variables=lambda a: {"mount_name": a.name}
     )
-    def mount_sub(mount_name):
+    def mount_sub(mount_name: str) -> sub:
         return sub(name=mount_name)
 
     c = Client(root())
@@ -1096,12 +1142,12 @@ def test_access_app_through_request():
     assert response.body == b"http://localhost/foo"
 
 
-def test_mount_ancestors():
+def test_mount_ancestors() -> None:
     class app(morepath.App):
         pass
 
     class mounted(morepath.App):
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @app.path(path="")
@@ -1109,7 +1155,7 @@ def test_mount_ancestors():
         pass
 
     @app.view(model=AppRoot)
-    def app_root_default(self, request):
+    def app_root_default(self: AppRoot, request: morepath.Request) -> None:
         ancestors = list(request.app.ancestors())
         assert len(ancestors) == 1
         assert ancestors[0] is request.app
@@ -1120,7 +1166,9 @@ def test_mount_ancestors():
         pass
 
     @mounted.view(model=MountedRoot)
-    def mounted_root_default(self, request):
+    def mounted_root_default(
+        self: MountedRoot, request: morepath.Request
+    ) -> None:
         ancestors = list(request.app.ancestors())
         assert len(ancestors) == 2
         assert ancestors[0] is request.app
@@ -1128,7 +1176,7 @@ def test_mount_ancestors():
         assert request.app.root is request.app.parent
 
     @app.mount(path="{id}", app=mounted)
-    def get_mounted(id):
+    def get_mounted(id: str) -> mounted:
         return mounted(id=id)
 
     c = Client(app())
@@ -1137,7 +1185,7 @@ def test_mount_ancestors():
     c.get("/foo")
 
 
-def test_breadthfist_vs_inheritance_on_commit():
+def test_breadthfist_vs_inheritance_on_commit() -> None:
     class Root(morepath.App):
         pass
 
@@ -1162,11 +1210,11 @@ def test_breadthfist_vs_inheritance_on_commit():
         pass
 
     @App1.view(model=Model1)
-    def view1(self, request):
+    def view1(self: Model1, request: morepath.Request) -> str:
         return type(request.app).__name__
 
     @App2.view(model=Model2)
-    def view2(self, request):
+    def view2(self: Model2, request: morepath.Request) -> str:
         return type(request.app).__name__
 
     Root.mount(app=App1, path="a/")(App1)

--- a/morepath/tests/test_path_directive.py
+++ b/morepath/tests/test_path_directive.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from webtest import TestApp as Client
 
@@ -12,24 +14,24 @@ from morepath.error import (
 )
 
 
-def test_simple_path_one_step():
+def test_simple_path_one_step() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
     @app.path(model=Model, path="simple")
-    def get_model():
+    def get_model() -> Model:
         return Model()
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View"
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -41,24 +43,24 @@ def test_simple_path_one_step():
     assert response.body == b"http://localhost/simple"
 
 
-def test_simple_path_two_steps():
+def test_simple_path_two_steps() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
     @app.path(model=Model, path="one/two")
-    def get_model():
+    def get_model() -> Model:
         return Model()
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View"
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -70,24 +72,24 @@ def test_simple_path_two_steps():
     assert response.body == b"http://localhost/one/two"
 
 
-def test_variable_path_one_step():
+def test_variable_path_one_step() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, name):
+        def __init__(self, name: str) -> None:
             self.name = name
 
     @app.path(model=Model, path="{name}")
-    def get_model(name):
+    def get_model(name: str) -> Model:
         return Model(name)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View: %s" % self.name
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -99,24 +101,24 @@ def test_variable_path_one_step():
     assert response.body == b"http://localhost/foo"
 
 
-def test_variable_path_two_steps():
+def test_variable_path_two_steps() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, name):
+        def __init__(self, name: str) -> None:
             self.name = name
 
     @app.path(model=Model, path="document/{name}")
-    def get_model(name):
+    def get_model(name: str) -> Model:
         return Model(name)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View: %s" % self.name
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -128,25 +130,25 @@ def test_variable_path_two_steps():
     assert response.body == b"http://localhost/document/foo"
 
 
-def test_variable_path_two_variables():
+def test_variable_path_two_variables() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, name, version):
+        def __init__(self, name: str, version: str) -> None:
             self.name = name
             self.version = version
 
     @app.path(model=Model, path="{name}-{version}")
-    def get_model(name, version):
+    def get_model(name: str, version: str) -> Model:
         return Model(name, version)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return f"View: {self.name} {self.version}"
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -158,24 +160,24 @@ def test_variable_path_two_variables():
     assert response.body == b"http://localhost/foo-one"
 
 
-def test_variable_path_explicit_converter():
+def test_variable_path_explicit_converter() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: int) -> None:
             self.id = id
 
     @app.path(model=Model, path="{id}", converters=dict(id=Converter(int)))
-    def get_model(id):
+    def get_model(id: int) -> Model:
         return Model(id)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return f"View: {self.id} ({type(self.id)})"
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -192,24 +194,24 @@ def test_variable_path_explicit_converter():
     response = c.get("/broken", status=404)
 
 
-def test_variable_path_implicit_converter():
+def test_variable_path_implicit_converter() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: int) -> None:
             self.id = id
 
     @app.path(model=Model, path="{id}")
-    def get_model(id=0):
+    def get_model(id: int = 0) -> Model:
         return Model(id)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return f"View: {self.id} ({type(self.id)})"
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -226,24 +228,24 @@ def test_variable_path_implicit_converter():
     response = c.get("/broken", status=404)
 
 
-def test_variable_path_explicit_trumps_implicit():
+def test_variable_path_explicit_trumps_implicit() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str | int) -> None:
             self.id = id
 
     @app.path(model=Model, path="{id}", converters=dict(id=Converter(int)))
-    def get_model(id="foo"):
+    def get_model(id: int | str = "foo") -> Model:
         return Model(id)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return f"View: {self.id} ({type(self.id)})"
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -260,24 +262,24 @@ def test_variable_path_explicit_trumps_implicit():
     response = c.get("/broken", status=404)
 
 
-def test_url_parameter_explicit_converter():
+def test_url_parameter_explicit_converter() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: int) -> None:
             self.id = id
 
     @app.path(model=Model, path="/", converters=dict(id=Converter(int)))
-    def get_model(id):
+    def get_model(id: int) -> Model:
         return Model(id)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return f"View: {self.id} ({type(self.id)})"
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -300,27 +302,27 @@ def test_url_parameter_explicit_converter():
     )
 
 
-def test_url_parameter_explicit_converter_get_converters():
+def test_url_parameter_explicit_converter_get_converters() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: int) -> None:
             self.id = id
 
-    def get_converters():
+    def get_converters() -> dict[str, Converter[int]]:
         return dict(id=Converter(int))
 
     @app.path(model=Model, path="/", get_converters=get_converters)
-    def get_model(id):
+    def get_model(id: int) -> Model:
         return Model(id)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return f"View: {self.id} ({type(self.id)})"
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -343,32 +345,32 @@ def test_url_parameter_explicit_converter_get_converters():
     )
 
 
-def test_url_parameter_get_converters_overrides_converters():
+def test_url_parameter_get_converters_overrides_converters() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: int) -> None:
             self.id = id
 
-    def get_converters():
+    def get_converters() -> dict[str, Converter[int]]:
         return dict(id=Converter(int))
 
     @app.path(
         model=Model,
         path="/",
-        converters={id: str},
+        converters={"id": str},
         get_converters=get_converters,
     )
-    def get_model(id):
+    def get_model(id: int) -> Model:
         return Model(id)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return f"View: {self.id} ({type(self.id)})"
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -391,24 +393,24 @@ def test_url_parameter_get_converters_overrides_converters():
     )
 
 
-def test_url_parameter_implicit_converter():
+def test_url_parameter_implicit_converter() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: int) -> None:
             self.id = id
 
     @app.path(model=Model, path="/")
-    def get_model(id=0):
+    def get_model(id: int = 0) -> Model:
         return Model(id)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return f"View: {self.id} ({type(self.id)})"
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -431,21 +433,21 @@ def test_url_parameter_implicit_converter():
     )
 
 
-def test_multiple_url_parameters_stable_order():
+def test_multiple_url_parameters_stable_order() -> None:
     class App(morepath.App):
         pass
 
     class Model:
-        def __init__(self, a, b):
+        def __init__(self, a: str, b: str) -> None:
             self.a = a
             self.b = b
 
     @App.path(model=Model, path="/")
-    def get_model(a, b):
+    def get_model(a: str, b: str) -> Model:
         return Model(a, b)
 
     @App.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(App())
@@ -454,24 +456,24 @@ def test_multiple_url_parameters_stable_order():
     assert response.body == b"http://localhost/?a=A&b=B"
 
 
-def test_url_parameter_explicit_trumps_implicit():
+def test_url_parameter_explicit_trumps_implicit() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: int | str) -> None:
             self.id = id
 
     @app.path(model=Model, path="/", converters=dict(id=Converter(int)))
-    def get_model(id="foo"):
+    def get_model(id: int | str = "foo") -> Model:
         return Model(id)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return f"View: {self.id} ({type(self.id)})"
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -494,18 +496,18 @@ def test_url_parameter_explicit_trumps_implicit():
     )
 
 
-def test_decode_encode():
+def test_decode_encode() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
-    def my_decode(s):
+    def my_decode(s: str) -> str:
         return s + "ADD"
 
-    def my_encode(s):
+    def my_encode(s: str) -> str:
         return s[: -len("ADD")]
 
     @app.path(
@@ -513,15 +515,15 @@ def test_decode_encode():
         path="/",
         converters=dict(id=Converter(my_decode, my_encode)),
     )
-    def get_model(id):
+    def get_model(id: str) -> Model:
         return Model(id)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View: %s" % self.id
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -533,46 +535,46 @@ def test_decode_encode():
     assert response.body == b"http://localhost/?id=foo"
 
 
-def test_unknown_converter():
+def test_unknown_converter() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, d):
+        def __init__(self, d: object) -> None:
             self.d = d
 
     class Unknown:
         pass
 
     @app.path(model=Model, path="/")
-    def get_model(d=Unknown()):
+    def get_model(d: Unknown = Unknown()) -> Model:
         return Model(d)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View: %s" % self.d
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     with pytest.raises(DirectiveReportError):
         app.commit()
 
 
-def test_not_all_path_variables_arguments_of_model_factory():
+def test_not_all_path_variables_arguments_of_model_factory() -> None:
     class App(morepath.App):
         pass
 
     class Model:
-        def __init__(self, foo):
+        def __init__(self, foo: str) -> None:
             self.foo = foo
 
     class Unknown:
         pass
 
     @App.path(model=Model, path="/{foo}/{bar}")
-    def get_model(foo):
+    def get_model(foo: str) -> Model:
         return Model(foo)
 
     with pytest.raises(DirectiveReportError) as e:
@@ -582,53 +584,53 @@ def test_not_all_path_variables_arguments_of_model_factory():
     )
 
 
-def test_unknown_explicit_converter():
+def test_unknown_explicit_converter() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, d):
+        def __init__(self, d: Unknown) -> None:
             self.d = d
 
     class Unknown:
         pass
 
     @app.path(model=Model, path="/", converters={"d": Unknown})
-    def get_model(d):
+    def get_model(d: Unknown) -> Model:
         return Model(d)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View: %s" % self.d
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     with pytest.raises(DirectiveReportError):
         app.commit()
 
 
-def test_default_date_converter():
+def test_default_date_converter() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, d):
+        def __init__(self, d: date) -> None:
             self.d = d
 
     from datetime import date
 
     @app.path(model=Model, path="/")
-    def get_model(d=date(2011, 1, 1)):
+    def get_model(d: date = date(2011, 1, 1)) -> Model:
         return Model(d)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View: %s" % self.d
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -648,26 +650,26 @@ def test_default_date_converter():
     response = c.get("/?d=broken", status=400)
 
 
-def test_default_datetime_converter():
+def test_default_datetime_converter() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, d):
+        def __init__(self, d: datetime) -> None:
             self.d = d
 
     from datetime import datetime
 
     @app.path(model=Model, path="/")
-    def get_model(d=datetime(2011, 1, 1, 10, 30)):
+    def get_model(d: datetime = datetime(2011, 1, 1, 10, 30)) -> Model:
         return Model(d)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View: %s" % self.d
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -687,37 +689,37 @@ def test_default_datetime_converter():
     c.get("/?d=broken", status=400)
 
 
-def test_custom_date_converter():
+def test_custom_date_converter() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, d):
+        def __init__(self, d: date) -> None:
             self.d = d
 
     from datetime import date
     from time import mktime, strptime
 
-    def date_decode(s):
+    def date_decode(s: str) -> date:
         return date.fromtimestamp(mktime(strptime(s, "%d-%m-%Y")))
 
-    def date_encode(d):
+    def date_encode(d: date) -> str:
         return d.strftime("%d-%m-%Y")
 
     @app.converter(type=date)
-    def date_converter():
+    def date_converter() -> Converter[date]:
         return Converter(date_decode, date_encode)
 
     @app.path(model=Model, path="/")
-    def get_model(d=date(2011, 1, 1)):
+    def get_model(d: date = date(2011, 1, 1)) -> Model:
         return Model(d)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View: %s" % self.d
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -737,24 +739,24 @@ def test_custom_date_converter():
     response = c.get("/?d=broken", status=400)
 
 
-def test_variable_path_parameter_required_no_default():
+def test_variable_path_parameter_required_no_default() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @app.path(model=Model, path="", required=["id"])
-    def get_model(id):
+    def get_model(id: str) -> Model:
         return Model(id)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View: %s" % self.id
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -765,24 +767,24 @@ def test_variable_path_parameter_required_no_default():
     response = c.get("/", status=400)
 
 
-def test_variable_path_parameter_required_with_default():
+def test_variable_path_parameter_required_with_default() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @app.path(model=Model, path="", required=["id"])
-    def get_model(id="b"):
+    def get_model(id: str = "b") -> Model:
         return Model(id)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View: %s" % self.id
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -793,26 +795,26 @@ def test_variable_path_parameter_required_with_default():
     response = c.get("/", status=400)
 
 
-def test_type_hints_and_converters():
+def test_type_hints_and_converters() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, d):
+        def __init__(self, d: date) -> None:
             self.d = d
 
     from datetime import date
 
     @app.path(model=Model, path="", converters=dict(d=date))
-    def get_model(d):
+    def get_model(d: date) -> Model:
         return Model(d)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View: %s" % self.d
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -824,24 +826,24 @@ def test_type_hints_and_converters():
     assert response.body == b"http://localhost/?d=20140120"
 
 
-def test_link_for_none_means_no_parameter():
+def test_link_for_none_means_no_parameter() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str | None) -> None:
             self.id = id
 
     @app.path(model=Model, path="")
-    def get_model(id):
+    def get_model(id: str | None) -> Model:
         return Model(id)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View: %s" % self.id
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -853,27 +855,27 @@ def test_link_for_none_means_no_parameter():
     assert response.body == b"http://localhost/"
 
 
-def test_path_and_url_parameter_converter():
+def test_path_and_url_parameter_converter() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id, param):
+        def __init__(self, id: int, param: date | None) -> None:
             self.id = id
             self.param = param
 
     from datetime import date
 
     @app.path(model=Model, path="/{id}", converters=dict(param=date))
-    def get_model(id=0, param=None):
+    def get_model(id: int = 0, param: date | None = None) -> Model:
         return Model(id, param)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return f"View: {self.id} {self.param}"
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -882,7 +884,7 @@ def test_path_and_url_parameter_converter():
     assert response.body == b"http://localhost/1"
 
 
-def test_path_converter_fallback_on_view():
+def test_path_converter_fallback_on_view() -> None:
     class app(morepath.App):
         pass
 
@@ -890,23 +892,23 @@ def test_path_converter_fallback_on_view():
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: int) -> None:
             self.id = id
 
     @app.path(model=Root, path="")
-    def get_root():
+    def get_root() -> Root:
         return Root()
 
     @app.path(model=Model, path="/{id}")
-    def get_model(id=0):
+    def get_model(id: int = 0) -> Model:
         return Model(id)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "Default view for %s" % self.id
 
     @app.view(model=Root, name="named")
-    def named(self, request):
+    def named(self: Root, request: morepath.Request) -> str:
         return "Named view on root"
 
     c = Client(app())
@@ -917,7 +919,7 @@ def test_path_converter_fallback_on_view():
     assert response.body == b"Named view on root"
 
 
-def test_root_named_link():
+def test_root_named_link() -> None:
     class app(morepath.App):
         pass
 
@@ -926,7 +928,7 @@ def test_root_named_link():
         pass
 
     @app.view(model=Root)
-    def default(self, request):
+    def default(self: Root, request: morepath.Request) -> str:
         return request.link(self, "foo")
 
     c = Client(app())
@@ -935,7 +937,7 @@ def test_root_named_link():
     assert response.body == b"http://localhost/foo"
 
 
-def test_path_class_and_model_argument():
+def test_path_class_and_model_argument() -> None:
     class app(morepath.App):
         pass
 
@@ -950,36 +952,36 @@ def test_path_class_and_model_argument():
         app.commit()
 
 
-def test_path_no_class_and_no_model_argument():
+def test_path_no_class_and_no_model_argument() -> None:
     class app(morepath.App):
         pass
 
     @app.path(path="")
-    def get_foo():
+    def get_foo() -> None:
         return None
 
     with pytest.raises(ConfigError):
         app.commit()
 
 
-def test_url_parameter_list():
+def test_url_parameter_list() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, item):
+        def __init__(self, item: list[int]) -> None:
             self.item = item
 
     @app.path(model=Model, path="/", converters={"item": [int]})
-    def get_model(item):
+    def get_model(item: list[int]) -> Model:
         return Model(item)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return repr(self.item)
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -999,30 +1001,30 @@ def test_url_parameter_list():
     assert response.body == b"[]"
 
 
-def test_url_parameter_list_empty():
+def test_url_parameter_list_empty() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, item):
+        def __init__(self, item: list[str]) -> None:
             self.item = item
 
     @app.path(model=Model, path="/", converters={"item": []})
-    def get_model(item):
+    def get_model(item: list[str]) -> Model:
         return Model(item)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return repr(self.item)
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
 
     response = c.get("/?item=a&item=b")
-    assert response.body in (b"[u'a', u'b']", b"['a', 'b']")
+    assert response.body == b"['a', 'b']"
 
     response = c.get("/link?item=a&item=b")
     assert response.body == b"http://localhost/?item=a&item=b"
@@ -1034,24 +1036,24 @@ def test_url_parameter_list_empty():
     assert response.body == b"[]"
 
 
-def test_url_parameter_list_explicit_converter():
+def test_url_parameter_list_explicit_converter() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, item):
+        def __init__(self, item: list[int]) -> None:
             self.item = item
 
     @app.path(model=Model, path="/", converters={"item": [Converter(int)]})
-    def get_model(item):
+    def get_model(item: list[int]) -> Model:
         return Model(item)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return repr(self.item)
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -1071,43 +1073,43 @@ def test_url_parameter_list_explicit_converter():
     assert response.body == b"[]"
 
 
-def test_url_parameter_list_unknown_explicit_converter():
+def test_url_parameter_list_unknown_explicit_converter() -> None:
     class app(morepath.App):
         pass
-
-    class Model:
-        def __init__(self, item):
-            self.item = item
 
     class Unknown:
         pass
 
+    class Model:
+        def __init__(self, item: list[Unknown]) -> None:
+            self.item = item
+
     @app.path(model=Model, path="/", converters={"item": [Unknown]})
-    def get_model(item):
+    def get_model(item: list[Unknown]) -> Model:
         return Model(item)
 
     with pytest.raises(DirectiveReportError):
         app.commit()
 
 
-def test_url_parameter_list_but_only_one_allowed():
+def test_url_parameter_list_but_only_one_allowed() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, item):
+        def __init__(self, item: int) -> None:
             self.item = item
 
     @app.path(model=Model, path="/", converters={"item": int})
-    def get_model(item):
+    def get_model(item: int) -> Model:
         return Model(item)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return repr(self.item)
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -1117,33 +1119,30 @@ def test_url_parameter_list_but_only_one_allowed():
     c.get("/link?item=1&item=2", status=400)
 
 
-def test_extra_parameters():
+def test_extra_parameters() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, extra_parameters):
+        def __init__(self, extra_parameters: dict[str, str]) -> None:
             self.extra_parameters = extra_parameters
 
     @app.path(model=Model, path="/")
-    def get_model(extra_parameters):
+    def get_model(extra_parameters: dict[str, str]) -> Model:
         return Model(extra_parameters)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return repr(sorted(self.extra_parameters.items()))
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
 
     response = c.get("/?a=A&b=B")
-    assert response.body in (
-        b"[(u'a', u'A'), (u'b', u'B')]",
-        b"[('a', 'A'), ('b', 'B')]",
-    )
+    assert response.body == b"[('a', 'A'), ('b', 'B')]"
     response = c.get("/link?a=A&b=B")
     assert sorted(response.body[len("http://localhost/?") :].split(b"&")) == [
         b"a=A",
@@ -1151,39 +1150,36 @@ def test_extra_parameters():
     ]
 
 
-def test_extra_parameters_with_get_converters():
+def test_extra_parameters_with_get_converters() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, extra_parameters):
+        def __init__(self, extra_parameters: dict[str, int | str]) -> None:
             self.extra_parameters = extra_parameters
 
-    def get_converters():
+    def get_converters() -> dict[str, type[object]]:
         return {
             "a": int,
             "b": str,
         }
 
     @app.path(model=Model, path="/", get_converters=get_converters)
-    def get_model(extra_parameters):
+    def get_model(extra_parameters: dict[str, int | str]) -> Model:
         return Model(extra_parameters)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return repr(sorted(self.extra_parameters.items()))
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
 
     response = c.get("/?a=1&b=B")
-    assert response.body in (
-        b"[(u'a', 1), (u'b', u'B')]",
-        b"[('a', 1), ('b', 'B')]",
-    )
+    assert response.body == b"[('a', 1), ('b', 'B')]"
     response = c.get("/link?a=1&b=B")
     assert sorted(response.body[len("http://localhost/?") :].split(b"&")) == [
         b"a=1",
@@ -1193,24 +1189,24 @@ def test_extra_parameters_with_get_converters():
     c.get("/?a=broken&b=B", status=400)
 
 
-def test_script_name():
+def test_script_name() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
     @app.path(model=Model, path="simple")
-    def get_model():
+    def get_model() -> Model:
         return Model()
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View"
 
     @app.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(app())
@@ -1226,35 +1222,35 @@ def test_script_name():
     assert response.body == b"http://localhost/prefix/simple"
 
 
-def test_sub_path_different_variable():
+def test_sub_path_different_variable() -> None:
     # See discussion in https://github.com/morepath/morepath/issues/155
 
     class App(morepath.App):
         pass
 
     class Foo:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     class Bar:
-        def __init__(self, id, foo):
+        def __init__(self, id: str, foo: Foo) -> None:
             self.id = id
             self.foo = foo
 
     @App.path(model=Foo, path="{id}")
-    def get_foo(id):
+    def get_foo(id: str) -> Foo:
         return Foo(id)
 
     @App.path(model=Bar, path="{foo_id}/{bar_id}")
-    def get_client(foo_id, bar_id):
+    def get_client(foo_id: str, bar_id: str) -> Bar:
         return Bar(bar_id, Foo(foo_id))
 
     @App.view(model=Foo)
-    def default_sbar(self, request):
+    def default_sbar(self: Foo, request: morepath.Request) -> str:
         return "M: %s" % self.id
 
     @App.view(model=Bar)
-    def default_bar(self, request):
+    def default_bar(self: Bar, request: morepath.Request) -> str:
         return f"S: {self.id} {self.foo.id}"
 
     c = Client(App())
@@ -1269,7 +1265,7 @@ def test_sub_path_different_variable():
     assert str(ex.value) == "step {id} and {foo_id} are in conflict"
 
 
-def test_absorb_path():
+def test_absorb_path() -> None:
     class app(morepath.App):
         pass
 
@@ -1277,23 +1273,23 @@ def test_absorb_path():
         pass
 
     class Model:
-        def __init__(self, absorb):
+        def __init__(self, absorb: str) -> None:
             self.absorb = absorb
 
     @app.path(model=Root, path="")
-    def get_root():
+    def get_root() -> Root:
         return Root()
 
     @app.path(model=Model, path="foo", absorb=True)
-    def get_model(absorb):
+    def get_model(absorb: str) -> Model:
         return Model(absorb)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "%s" % self.absorb
 
     @app.view(model=Root)
-    def default_root(self, request):
+    def default_root(self: Root, request: morepath.Request) -> str:
         return request.link(Model("a/b"))
 
     c = Client(app())
@@ -1312,7 +1308,7 @@ def test_absorb_path():
     assert response.body == b"http://localhost/foo/a/b"
 
 
-def test_absorb_path_with_variables():
+def test_absorb_path_with_variables() -> None:
     class app(morepath.App):
         pass
 
@@ -1320,24 +1316,24 @@ def test_absorb_path_with_variables():
         pass
 
     class Model:
-        def __init__(self, id, absorb):
+        def __init__(self, id: str, absorb: str) -> None:
             self.id = id
             self.absorb = absorb
 
     @app.path(model=Root, path="")
-    def get_root():
+    def get_root() -> Root:
         return Root()
 
     @app.path(model=Model, path="{id}", absorb=True)
-    def get_model(id, absorb):
+    def get_model(id: str, absorb: str) -> Model:
         return Model(id, absorb)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return f"I:{self.id} A:{self.absorb}"
 
     @app.view(model=Root)
-    def default_root(self, request):
+    def default_root(self: Root, request: morepath.Request) -> str:
         return request.link(Model("foo", "a/b"))
 
     c = Client(app())
@@ -1356,7 +1352,7 @@ def test_absorb_path_with_variables():
     assert response.body == b"http://localhost/foo/a/b"
 
 
-def test_absorb_path_explicit_subpath_ignored():
+def test_absorb_path_explicit_subpath_ignored() -> None:
     class app(morepath.App):
         pass
 
@@ -1364,34 +1360,34 @@ def test_absorb_path_explicit_subpath_ignored():
         pass
 
     class Model:
-        def __init__(self, absorb):
+        def __init__(self, absorb: str) -> None:
             self.absorb = absorb
 
     class Another:
         pass
 
     @app.path(model=Root, path="")
-    def get_root():
+    def get_root() -> Root:
         return Root()
 
     @app.path(model=Model, path="foo", absorb=True)
-    def get_model(absorb):
+    def get_model(absorb: str) -> Model:
         return Model(absorb)
 
     @app.path(model=Another, path="foo/another")
-    def get_another():
+    def get_another() -> Another:
         return Another()
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "%s" % self.absorb
 
     @app.view(model=Another)
-    def default_another(self, request):
+    def default_another(self: Another, request: morepath.Request) -> str:
         return "Another"
 
     @app.view(model=Root)
-    def default_root(self, request):
+    def default_root(self: Root, request: morepath.Request) -> str:
         return request.link(Another())
 
     c = Client(app())
@@ -1407,20 +1403,20 @@ def test_absorb_path_explicit_subpath_ignored():
     assert response.body == b"http://localhost/foo/another"
 
 
-def test_absorb_path_root():
+def test_absorb_path_root() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, absorb):
+        def __init__(self, absorb: str) -> None:
             self.absorb = absorb
 
     @app.path(model=Model, path="", absorb=True)
-    def get_model(absorb):
+    def get_model(absorb: str) -> Model:
         return Model(absorb)
 
     @app.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return f"A:{self.absorb} L:{request.link(self)}"
 
     c = Client(app())
@@ -1435,22 +1431,22 @@ def test_absorb_path_root():
     assert response.body == b"A:a/b L:http://localhost/a/b"
 
 
-def test_path_explicit_variables():
+def test_path_explicit_variables() -> None:
     class App(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.store_id = id
 
     @App.path(
         model=Model, path="models/{id}", variables=lambda m: {"id": m.store_id}
     )
-    def get_model(id):
+    def get_model(id: str) -> Model:
         return Model(id)
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(App())
@@ -1459,24 +1455,24 @@ def test_path_explicit_variables():
     assert response.body == b"http://localhost/models/1"
 
 
-def test_path_explicit_variables_app_arg():
+def test_path_explicit_variables_app_arg() -> None:
     class App(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.store_id = id
 
-    def my_variables(app, m):
+    def my_variables(app: App, m: Model) -> dict[str, str]:
         assert isinstance(app, App)
         return {"id": m.store_id}
 
     @App.path(model=Model, path="models/{id}", variables=my_variables)
-    def get_model(id):
+    def get_model(id: str) -> Model:
         return Model(id)
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(App())
@@ -1485,20 +1481,20 @@ def test_path_explicit_variables_app_arg():
     assert response.body == b"http://localhost/models/1"
 
 
-def test_error_when_path_variable_is_none():
+def test_error_when_path_variable_is_none() -> None:
     class App(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.store_id = id
 
     @App.path(model=Model, path="models/{id}", variables=lambda m: {"id": None})
-    def get_model(id):
+    def get_model(id: str) -> Model:
         return Model(id)
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(App())
@@ -1507,20 +1503,20 @@ def test_error_when_path_variable_is_none():
         c.get("/models/1")
 
 
-def test_error_when_path_variable_is_missing():
+def test_error_when_path_variable_is_missing() -> None:
     class App(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.store_id = id
 
     @App.path(model=Model, path="models/{id}", variables=lambda m: {})
-    def get_model(id):
+    def get_model(id: str) -> Model:
         return Model(id)
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(App())
@@ -1529,20 +1525,20 @@ def test_error_when_path_variable_is_missing():
         c.get("/models/1")
 
 
-def test_error_when_path_variables_isnt_dict():
+def test_error_when_path_variables_isnt_dict() -> None:
     class App(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.store_id = id
 
-    @App.path(model=Model, path="models/{id}", variables=lambda m: "nondict")
-    def get_model(id):
+    @App.path(model=Model, path="models/{id}", variables=lambda m: "nondict")  # type: ignore
+    def get_model(id: str) -> Model:
         return Model(id)
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(App())
@@ -1551,29 +1547,29 @@ def test_error_when_path_variables_isnt_dict():
         c.get("/models/1")
 
 
-def test_resolve_path_method_on_request_same_app():
+def test_resolve_path_method_on_request_same_app() -> None:
     class App(morepath.App):
         pass
 
     class Model:
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
     @App.path(model=Model, path="simple")
-    def get_model():
+    def get_model() -> Model:
         return Model()
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return str(isinstance(request.resolve_path("simple"), Model))
 
     @App.view(model=Model, name="extra")
-    def extra(self, request):
+    def extra(self: Model, request: morepath.Request) -> str:
         return str(request.resolve_path("nonexistent") is None)
 
     @App.view(model=Model, name="appnone")
-    def appnone(self, request):
-        return request.resolve_path("simple", app=None)
+    def appnone(self: Model, request: morepath.Request) -> object:
+        return request.resolve_path("simple", app=None)  # type: ignore
 
     c = Client(App())
 
@@ -1585,21 +1581,23 @@ def test_resolve_path_method_on_request_same_app():
         c.get("/simple/appnone")
 
 
-def test_resolve_path_method_on_request_different_app():
+def test_resolve_path_method_on_request_different_app() -> None:
     class App(morepath.App):
         pass
 
     class Model:
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
     @App.path(model=Model, path="simple")
-    def get_model():
+    def get_model() -> Model:
         return Model()
 
     @App.view(model=Model)
-    def default(self, request):
-        obj = request.resolve_path("p", app=request.app.child("sub"))
+    def default(self: Model, request: morepath.Request) -> str:
+        child = request.app.child("sub")
+        assert child is not None
+        obj = request.resolve_path("p", app=child)
         return str(isinstance(obj, SubModel))
 
     class Sub(morepath.App):
@@ -1609,11 +1607,11 @@ def test_resolve_path_method_on_request_different_app():
         pass
 
     @Sub.path(model=SubModel, path="p")
-    def get_sub_model():
+    def get_sub_model() -> SubModel:
         return SubModel()
 
     @App.mount(path="sub", app=Sub)
-    def mount_sub():
+    def mount_sub() -> Sub:
         return Sub()
 
     c = Client(App())
@@ -1622,20 +1620,20 @@ def test_resolve_path_method_on_request_different_app():
     assert response.body == b"True"
 
 
-def test_resolve_path_with_dots_in_url():
+def test_resolve_path_with_dots_in_url() -> None:
     class app(morepath.App):
         pass
 
     class Root:
-        def __init__(self, absorb):
+        def __init__(self, absorb: str) -> None:
             self.absorb = absorb
 
     @app.path(model=Root, path="root", absorb=True)
-    def get_root(absorb):
+    def get_root(absorb: str) -> Root:
         return Root(absorb)
 
     @app.view(model=Root)
-    def default(self, request):
+    def default(self: Root, request: morepath.Request) -> str:
         return "%s" % self.absorb
 
     c = Client(app())
@@ -1656,24 +1654,24 @@ def test_resolve_path_with_dots_in_url():
     assert response.status_code == 404
 
 
-def test_quoting_link_generation():
+def test_quoting_link_generation() -> None:
     class App(morepath.App):
         pass
 
     class Model:
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
     @App.path(model=Model, path="sim?ple")
-    def get_model():
+    def get_model() -> Model:
         return Model()
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View"
 
     @App.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(App())
@@ -1685,24 +1683,24 @@ def test_quoting_link_generation():
     assert response.body == b"http://localhost/sim%3Fple"
 
 
-def test_quoting_link_generation_umlaut():
+def test_quoting_link_generation_umlaut() -> None:
     class App(morepath.App):
         pass
 
     class Model:
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
     @App.path(model=Model, path="simëple")
-    def get_model():
+    def get_model() -> Model:
         return Model()
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View"
 
     @App.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(App())
@@ -1714,7 +1712,7 @@ def test_quoting_link_generation_umlaut():
     assert response.body == b"http://localhost/sim%C3%ABple"
 
 
-def test_quoting_link_generation_tilde():
+def test_quoting_link_generation_tilde() -> None:
     # tilde is an unreserved character according to
     # https://www.ietf.org/rfc/rfc3986.txt but urllib.quote
     # quotes it anyway. We test whether our workaround using
@@ -1724,19 +1722,19 @@ def test_quoting_link_generation_tilde():
         pass
 
     class Model:
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
     @App.path(model=Model, path="sim~ple")
-    def get_model():
+    def get_model() -> Model:
         return Model()
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View"
 
     @App.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(App())
@@ -1748,24 +1746,24 @@ def test_quoting_link_generation_tilde():
     assert response.body == b"http://localhost/sim~ple"
 
 
-def test_parameter_quoting():
+def test_parameter_quoting() -> None:
     class App(morepath.App):
         pass
 
     class Model:
-        def __init__(self, s):
+        def __init__(self, s: str | None) -> None:
             self.s = s
 
     @App.path(model=Model, path="")
-    def get_model(s):
+    def get_model(s: str | None) -> Model:
         return Model(s)
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View: %s" % self.s
 
     @App.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(App())
@@ -1777,24 +1775,24 @@ def test_parameter_quoting():
     assert response.body == b"http://localhost/?s=sim%C3%ABple"
 
 
-def test_parameter_quoting_tilde():
+def test_parameter_quoting_tilde() -> None:
     class App(morepath.App):
         pass
 
     class Model:
-        def __init__(self, s):
+        def __init__(self, s: str | None) -> None:
             self.s = s
 
     @App.path(model=Model, path="")
-    def get_model(s):
+    def get_model(s: str | None) -> Model:
         return Model(s)
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View: %s" % self.s
 
     @App.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.link(self)
 
     c = Client(App())
@@ -1806,7 +1804,7 @@ def test_parameter_quoting_tilde():
     assert response.body == b"http://localhost/?s=sim~ple"
 
 
-def test_class_link_without_variables():
+def test_class_link_without_variables() -> None:
     class App(morepath.App):
         pass
 
@@ -1814,11 +1812,11 @@ def test_class_link_without_variables():
         pass
 
     @App.path(model=Model, path="/foo")
-    def get_model():
+    def get_model() -> Model:
         return Model()
 
     @App.view(model=Model)
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.class_link(Model)
 
     c = Client(App())
@@ -1827,7 +1825,7 @@ def test_class_link_without_variables():
     assert response.body == b"http://localhost/foo"
 
 
-def test_class_link_no_app():
+def test_class_link_no_app() -> None:
     class App(morepath.App):
         pass
 
@@ -1835,12 +1833,12 @@ def test_class_link_no_app():
         pass
 
     @App.path(model=Model, path="/foo")
-    def get_model():
+    def get_model() -> Model:
         return Model()
 
     @App.view(model=Model)
-    def link(self, request):
-        return request.class_link(Model, app=None)
+    def link(self: Model, request: morepath.Request) -> str:
+        return request.class_link(Model, app=None)  # type: ignore
 
     c = Client(App())
 
@@ -1848,7 +1846,7 @@ def test_class_link_no_app():
         c.get("/foo")
 
 
-def test_class_link_with_variables():
+def test_class_link_with_variables() -> None:
     class App(morepath.App):
         pass
 
@@ -1856,11 +1854,11 @@ def test_class_link_with_variables():
         pass
 
     @App.path(model=Model, path="/foo/{x}")
-    def get_model(x):
+    def get_model(x: str) -> Model:
         return Model()
 
     @App.view(model=Model)
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.class_link(Model, variables={"x": "X"})
 
     c = Client(App())
@@ -1869,7 +1867,7 @@ def test_class_link_with_variables():
     assert response.body == b"http://localhost/foo/X"
 
 
-def test_class_link_with_missing_variables():
+def test_class_link_with_missing_variables() -> None:
     class App(morepath.App):
         pass
 
@@ -1877,11 +1875,11 @@ def test_class_link_with_missing_variables():
         pass
 
     @App.path(model=Model, path="/foo/{x}")
-    def get_model(x):
+    def get_model(x: str) -> Model:
         return Model()
 
     @App.view(model=Model)
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.class_link(Model, variables={})
 
     c = Client(App())
@@ -1890,7 +1888,7 @@ def test_class_link_with_missing_variables():
         c.get("/foo/3")
 
 
-def test_class_link_with_extra_variable():
+def test_class_link_with_extra_variable() -> None:
     class App(morepath.App):
         pass
 
@@ -1898,11 +1896,11 @@ def test_class_link_with_extra_variable():
         pass
 
     @App.path(model=Model, path="/foo/{x}")
-    def get_model(x):
+    def get_model(x: str) -> Model:
         return Model()
 
     @App.view(model=Model)
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.class_link(Model, variables={"x": "X", "y": "Y"})
 
     c = Client(App())
@@ -1911,7 +1909,7 @@ def test_class_link_with_extra_variable():
     assert response.body == b"http://localhost/foo/X"
 
 
-def test_class_link_with_url_parameter_variable():
+def test_class_link_with_url_parameter_variable() -> None:
     class App(morepath.App):
         pass
 
@@ -1919,11 +1917,11 @@ def test_class_link_with_url_parameter_variable():
         pass
 
     @App.path(model=Model, path="/foo/{x}")
-    def get_model(x, y):
+    def get_model(x: str, y: str) -> Model:
         return Model()
 
     @App.view(model=Model)
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.class_link(Model, variables={"x": "X", "y": "Y"})
 
     c = Client(App())
@@ -1932,7 +1930,7 @@ def test_class_link_with_url_parameter_variable():
     assert response.body == b"http://localhost/foo/X?y=Y"
 
 
-def test_class_link_with_subclass():
+def test_class_link_with_subclass() -> None:
     class App(morepath.App):
         pass
 
@@ -1943,11 +1941,11 @@ def test_class_link_with_subclass():
         pass
 
     @App.path(model=Model, path="/foo/{x}")
-    def get_model(x):
+    def get_model(x: str) -> Model:
         return Model()
 
     @App.view(model=Model)
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.class_link(Sub, variables={"x": "X"})
 
     c = Client(App())
@@ -1956,7 +1954,7 @@ def test_class_link_with_subclass():
     assert response.body == b"http://localhost/foo/X"
 
 
-def test_absorb_class_path():
+def test_absorb_class_path() -> None:
     class App(morepath.App):
         pass
 
@@ -1964,23 +1962,23 @@ def test_absorb_class_path():
         pass
 
     class Model:
-        def __init__(self, absorb):
+        def __init__(self, absorb: str) -> None:
             self.absorb = absorb
 
     @App.path(model=Root, path="")
-    def get_root():
+    def get_root() -> Root:
         return Root()
 
     @App.path(model=Model, path="foo", absorb=True)
-    def get_model(absorb):
+    def get_model(absorb: str) -> Model:
         return Model(absorb)
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "%s" % self.absorb
 
     @App.view(model=Root)
-    def default_root(self, request):
+    def default_root(self: Root, request: morepath.Request) -> str:
         return request.class_link(Model, variables={"absorb": "a/b"})
 
     c = Client(App())
@@ -1990,7 +1988,7 @@ def test_absorb_class_path():
     assert response.body == b"http://localhost/foo/a/b"
 
 
-def test_absorb_class_path_with_variables():
+def test_absorb_class_path_with_variables() -> None:
     class App(morepath.App):
         pass
 
@@ -1998,24 +1996,24 @@ def test_absorb_class_path_with_variables():
         pass
 
     class Model:
-        def __init__(self, id, absorb):
+        def __init__(self, id: str, absorb: str) -> None:
             self.id = id
             self.absorb = absorb
 
     @App.path(model=Root, path="")
-    def get_root():
+    def get_root() -> Root:
         return Root()
 
     @App.path(model=Model, path="{id}", absorb=True)
-    def get_model(id, absorb):
+    def get_model(id: str, absorb: str) -> Model:
         return Model(id, absorb)
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return f"I:{self.id} A:{self.absorb}"
 
     @App.view(model=Root)
-    def default_root(self, request):
+    def default_root(self: Root, request: morepath.Request) -> str:
         return request.class_link(Model, variables=dict(id="foo", absorb="a/b"))
 
     c = Client(App())
@@ -2025,24 +2023,24 @@ def test_absorb_class_path_with_variables():
     assert response.body == b"http://localhost/foo/a/b"
 
 
-def test_class_link_extra_parameters():
+def test_class_link_extra_parameters() -> None:
     class App(morepath.App):
         pass
 
     class Model:
-        def __init__(self, extra_parameters):
+        def __init__(self, extra_parameters: dict[str, str]) -> None:
             self.extra_parameters = extra_parameters
 
     @App.path(model=Model, path="/")
-    def get_model(extra_parameters):
+    def get_model(extra_parameters: dict[str, str]) -> Model:
         return Model(extra_parameters)
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return repr(sorted(self.extra_parameters.items()))
 
     @App.view(model=Model, name="link")
-    def link(self, request):
+    def link(self: Model, request: morepath.Request) -> str:
         return request.class_link(
             Model, variables={"extra_parameters": {"a": "A", "b": "B"}}
         )
@@ -2056,13 +2054,13 @@ def test_class_link_extra_parameters():
     ]
 
 
-def test_path_on_model_class():
+def test_path_on_model_class() -> None:
     class App(morepath.App):
         pass
 
     @App.path("/")
     class Model:
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
     @App.path("/login")
@@ -2070,11 +2068,11 @@ def test_path_on_model_class():
         pass
 
     @App.view(model=Model)
-    def model_view(self, request):
+    def model_view(self: Model, request: morepath.Request) -> str:
         return "Model"
 
     @App.view(model=Login)
-    def login_view(self, request):
+    def login_view(self: Login, request: morepath.Request) -> str:
         return "Login"
 
     c = Client(App())
@@ -2085,19 +2083,19 @@ def test_path_on_model_class():
     assert response.body == b"Login"
 
 
-def test_path_without_model():
+def test_path_without_model() -> None:
     class App(morepath.App):
         pass
 
     @App.path("/")
-    def get_path():
+    def get_path() -> None:
         pass
 
     with pytest.raises(dectate.DirectiveReportError):
         App.commit()
 
 
-def test_two_path_on_same_model_should_conflict():
+def test_two_path_on_same_model_should_conflict() -> None:
     class App(morepath.App):
         pass
 
@@ -2110,7 +2108,7 @@ def test_two_path_on_same_model_should_conflict():
         App.commit()
 
 
-def test_path_on_same_model_explicit_and_class_should_conflict():
+def test_path_on_same_model_explicit_and_class_should_conflict() -> None:
     class App(morepath.App):
         pass
 
@@ -2119,27 +2117,27 @@ def test_path_on_same_model_explicit_and_class_should_conflict():
         pass
 
     @App.path("/login", model=Login)
-    def get_path():
+    def get_path() -> Login:
         return Login()
 
     with pytest.raises(dectate.ConflictError):
         App.commit()
 
 
-def test_nonexisting_path_too_long_unconsumed():
+def test_nonexisting_path_too_long_unconsumed() -> None:
     class App(morepath.App):
         pass
 
     class Model:
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
     @App.path(model=Model, path="simple")
-    def get_model():
+    def get_model() -> Model:
         return Model()
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View"
 
     c = Client(App())
@@ -2147,16 +2145,16 @@ def test_nonexisting_path_too_long_unconsumed():
     c.get("/foo/bar/baz", status=404)
 
 
-def test_collection_and_item():
+def test_collection_and_item() -> None:
     class App(morepath.App):
         pass
 
     class Collection:
-        def __init__(self):
-            self.items = {}
+        def __init__(self) -> None:
+            self.items: dict[str, Item] = {}
 
     class Item:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     collection = Collection()
@@ -2164,46 +2162,46 @@ def test_collection_and_item():
     collection.items["b"] = Item("b")
 
     @App.path(model=Collection, path="/")
-    def get_collection():
+    def get_collection() -> Collection:
         return collection
 
     @App.path(model=Item, path="/{id}")
-    def get_item(id):
+    def get_item(id: str) -> Item | None:
         return collection.items.get(id)
 
     @App.view(model=Collection)
-    def default_collection(self, request):
+    def default_collection(self: str, request: morepath.Request) -> str:
         return "Collection"
 
     @App.view(model=Item)
-    def default(self, request):
+    def default(self: Item, request: morepath.Request) -> str:
         return "View: %s" % self.id
 
     c = Client(App())
 
     r = c.get("/c", status=404)
-    assert r.body != "Collection"
+    assert r.body != b"Collection"
 
     r = c.get("/a")
     assert r.body == b"View: a"
 
 
-def test_view_for_missing():
+def test_view_for_missing() -> None:
     class App(morepath.App):
         pass
 
     class Item:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @App.path(model=Item, path="/{id}")
-    def get_item(id):
+    def get_item(id: str) -> Item | None:
         if id == "found":
             return Item(id)
         return None
 
     @App.view(model=Item, name="edit")
-    def default(self, request):
+    def default(self: Item, request: morepath.Request) -> str:
         return "View: %s" % self.id
 
     c = Client(App())
@@ -2213,7 +2211,7 @@ def test_view_for_missing():
     c.get("/notfound/edit", status=404)
 
 
-def test_absorb_error():
+def test_absorb_error() -> None:
     class App(morepath.App):
         pass
 
@@ -2222,21 +2220,21 @@ def test_absorb_error():
         pass
 
     @App.view(model=Root)
-    def view_root(self, request):
+    def view_root(self: Root, request: morepath.Request) -> str:
         return "root"
 
     class File:
-        def __init__(self, absorb):
+        def __init__(self, absorb: str) -> None:
             self.absorb = absorb
 
     @App.path("/files", model=File, absorb=True)
-    def get_file(absorb):
+    def get_file(absorb: str) -> File | None:
         if absorb == "foo":
             return File("foo")
         return None
 
     @App.view(model=File)
-    def view_file(self, request):
+    def view_file(self: File, request: morepath.Request) -> str:
         return request.path
 
     App.commit()
@@ -2247,7 +2245,7 @@ def test_absorb_error():
     client.get("/files/bar", status=404)
 
 
-def test_named_view_on_root():
+def test_named_view_on_root() -> None:
     class App(morepath.App):
         pass
 
@@ -2256,11 +2254,11 @@ def test_named_view_on_root():
         pass
 
     @App.view(model=Root, name="named")
-    def named(self, request):
+    def named(self: Root, request: morepath.Request) -> str:
         return "Named view on root"
 
     @App.view(model=Root)
-    def default(self, request):
+    def default(self: Root, request: morepath.Request) -> str:
         return "Default view on root"
 
     c = Client(App())

--- a/morepath/tests/test_predicate.py
+++ b/morepath/tests/test_predicate.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
+
+from typing import Any
+
 import morepath
 from reg import ClassIndex, KeyIndex
 
 
-def test_dispatch_method_directive():
+def test_dispatch_method_directive() -> None:
     class App(morepath.App):
         @morepath.dispatch_method("obj")
-        def f(self, obj):
+        def f(self, obj: Any) -> str:
             return "fallback"
 
     class Foo:
@@ -18,11 +22,11 @@ def test_dispatch_method_directive():
         pass
 
     @App.method(App.f, obj=Foo)
-    def f_foo(self, obj):
+    def f_foo(self: App, obj: Foo) -> str:
         return "foo"
 
     @App.method(App.f, obj=Bar)
-    def f_bar(self, obj):
+    def f_bar(self: App, obj: Bar) -> str:
         return "bar"
 
     a = App()
@@ -32,10 +36,10 @@ def test_dispatch_method_directive():
     assert a.f(Other()) == "fallback"
 
 
-def test_dispatch_function_directive():
+def test_dispatch_function_directive() -> None:
     class App(morepath.App):
         @morepath.dispatch_method("obj")
-        def f(self, obj):
+        def f(self, obj: Any) -> str:
             return "fallback"
 
     class Foo:
@@ -48,11 +52,11 @@ def test_dispatch_function_directive():
         pass
 
     @App.method(App.f, obj=Foo)
-    def f_foo(app, obj):
+    def f_foo(app: App, obj: Foo) -> str:
         return "foo"
 
     @App.method(App.f, obj=Bar)
-    def f_bar(app, obj):
+    def f_bar(app: App, obj: Bar) -> str:
         return "bar"
 
     a = App()
@@ -62,10 +66,10 @@ def test_dispatch_function_directive():
     assert a.f(Other()) == "fallback"
 
 
-def test_dispatch_external_predicates():
+def test_dispatch_external_predicates() -> None:
     class App(morepath.App):
         @morepath.dispatch_method()
-        def f(app, obj):
+        def f(app, obj: Any) -> str:
             return "fallback"
 
     class Foo:
@@ -78,15 +82,15 @@ def test_dispatch_external_predicates():
         pass
 
     @App.predicate(App.f, name="model", default=None, index=ClassIndex)
-    def f_obj(app, obj):
+    def f_obj(app: App, obj: object) -> type[Any]:
         return obj.__class__
 
     @App.method(App.f, model=Foo)
-    def f_foo(app, obj):
+    def f_foo(app: App, obj: Foo) -> str:
         return "foo"
 
     @App.method(App.f, model=Bar)
-    def f_bar(app, obj):
+    def f_bar(app: App, obj: Bar) -> str:
         return "bar"
 
     a = App()
@@ -96,10 +100,10 @@ def test_dispatch_external_predicates():
     assert a.f(Other()) == "fallback"
 
 
-def test_dispatch_external_predicates_predicate_fallback():
+def test_dispatch_external_predicates_predicate_fallback() -> None:
     class App(morepath.App):
         @morepath.dispatch_method()
-        def f(app, obj):
+        def f(app, obj: Any) -> str:
             return "dispatch function"
 
     class Foo:
@@ -112,19 +116,19 @@ def test_dispatch_external_predicates_predicate_fallback():
         pass
 
     @App.predicate(App.f, name="model", default=None, index=ClassIndex)
-    def f_obj(app, obj):
+    def f_obj(app: App, obj: object) -> type[Any]:
         return obj.__class__
 
     @App.predicate_fallback(App.f, f_obj)
-    def f_obj_fallback(app, obj):
+    def f_obj_fallback(app: App, obj: Any) -> str:
         return "f_obj_fallback"
 
     @App.method(App.f, model=Foo)
-    def f_foo(app, obj):
+    def f_foo(app: App, obj: Foo) -> str:
         return "foo"
 
     @App.method(App.f, model=Bar)
-    def f_bar(app, obj):
+    def f_bar(app: App, obj: Foo) -> str:
         return "bar"
 
     a = App()
@@ -134,10 +138,10 @@ def test_dispatch_external_predicates_predicate_fallback():
     assert a.f(Other()) == "f_obj_fallback"
 
 
-def test_dispatch_external_predicates_ordering_after():
+def test_dispatch_external_predicates_ordering_after() -> None:
     class App(morepath.App):
         @morepath.dispatch_method()
-        def f(app, obj, name):
+        def f(app, obj: Any, name: str) -> str:
             return "fallback"
 
     class Foo:
@@ -150,29 +154,29 @@ def test_dispatch_external_predicates_ordering_after():
         pass
 
     @App.predicate(App.f, name="model", default=None, index=ClassIndex)
-    def pred_obj(app, obj, name):
+    def pred_obj(app: App, obj: object, name: str) -> type[Any]:
         return obj.__class__
 
     @App.predicate(
         App.f, name="name", default="", index=KeyIndex, after=pred_obj
     )
-    def pred_name(app, obj, name):
+    def pred_name(app: App, obj: object, name: str) -> str:
         return name
 
     @App.method(App.f, model=Foo, name="")
-    def f_foo_default(app, obj, name):
+    def f_foo_default(app: App, obj: Foo, name: str) -> str:
         return "foo default"
 
     @App.method(App.f, model=Foo, name="edit")
-    def f_foo_edit(app, obj, name):
+    def f_foo_edit(app: App, obj: Foo, name: str) -> str:
         return "foo edit"
 
     @App.method(App.f, model=Bar, name="")
-    def f_bar_default(app, obj, name):
+    def f_bar_default(app: App, obj: Bar, name: str) -> str:
         return "bar default"
 
     @App.method(App.f, model=Bar, name="edit")
-    def f_bar_edit(app, obj, name):
+    def f_bar_edit(app: App, obj: Bar, name: str) -> str:
         return "bar edit"
 
     a = App()
@@ -186,10 +190,10 @@ def test_dispatch_external_predicates_ordering_after():
     assert a.f(Other(), "edit") == "fallback"
 
 
-def test_dispatch_external_predicates_ordering_before():
+def test_dispatch_external_predicates_ordering_before() -> None:
     class App(morepath.App):
         @morepath.dispatch_method()
-        def f(app, obj, name):
+        def f(app, obj: Any, name: str) -> str:
             return "fallback"
 
     class Foo:
@@ -202,29 +206,29 @@ def test_dispatch_external_predicates_ordering_before():
         pass
 
     @App.predicate(App.f, name="name", default="", index=KeyIndex)
-    def pred_name(app, obj, name):
+    def pred_name(app: App, obj: object, name: str) -> str:
         return name
 
     @App.predicate(
         App.f, name="model", default=None, index=ClassIndex, before=pred_name
     )
-    def pred_obj(app, obj, name):
+    def pred_obj(app: App, obj: object, name: str) -> type[Any]:
         return obj.__class__
 
     @App.method(App.f, model=Foo, name="")
-    def f_foo_default(app, obj, name):
+    def f_foo_default(app: App, obj: Foo, name: str) -> str:
         return "foo default"
 
     @App.method(App.f, model=Foo, name="edit")
-    def f_foo_edit(app, obj, name):
+    def f_foo_edit(app: App, obj: Foo, name: str) -> str:
         return "foo edit"
 
     @App.method(App.f, model=Bar, name="")
-    def f_bar_default(app, obj, name):
+    def f_bar_default(app: App, obj: Bar, name: str) -> str:
         return "bar default"
 
     @App.method(App.f, model=Bar, name="edit")
-    def f_bar_edit(app, obj, name):
+    def f_bar_edit(app: App, obj: Bar, name: str) -> str:
         return "bar edit"
 
     a = App()
@@ -238,10 +242,10 @@ def test_dispatch_external_predicates_ordering_before():
     assert a.f(Other(), "edit") == "fallback"
 
 
-def test_dispatch_external_override_fallback():
+def test_dispatch_external_override_fallback() -> None:
     class App(morepath.App):
         @morepath.dispatch_method()
-        def f(self, obj):
+        def f(self, obj: Any) -> str:
             return "dispatch function"
 
     class Sub(App):
@@ -257,27 +261,27 @@ def test_dispatch_external_override_fallback():
         pass
 
     @App.predicate(App.f, name="model", default=None, index=ClassIndex)
-    def f_obj(self, obj):
+    def f_obj(self: App, obj: object) -> type[Any]:
         return obj.__class__
 
     @App.predicate_fallback(App.f, f_obj)
-    def f_obj_fallback(self, obj):
+    def f_obj_fallback(self: App, obj: object) -> str:
         return "f_obj_fallback"
 
     @Sub.predicate_fallback(App.f, f_obj)
-    def f_obj_fallback_sub(self, obj):
+    def f_obj_fallback_sub(self: Sub, obj: object) -> str:
         return "f_obj_fallback sub"
 
     @App.method(App.f, model=Foo)
-    def f_foo(self, obj):
+    def f_foo(self: App, obj: Foo) -> str:
         return "foo"
 
     @Sub.method(App.f, model=Foo)
-    def f_foo_sub(self, obj):
+    def f_foo_sub(self: Sub, obj: Foo) -> str:
         return "foo sub"
 
     @App.method(App.f, model=Bar)
-    def f_bar(self, obj):
+    def f_bar(self: App, obj: Bar) -> str:
         return "bar"
 
     s = Sub()
@@ -294,10 +298,10 @@ def test_dispatch_external_override_fallback():
     assert a.f(Other()) == "f_obj_fallback"
 
 
-def test_dispatch_external_override_predicate():
+def test_dispatch_external_override_predicate() -> None:
     class App(morepath.App):
         @morepath.dispatch_method()
-        def f(app, obj):
+        def f(app, obj: Any) -> str:
             return "dispatch function"
 
     class Sub(App):
@@ -313,31 +317,31 @@ def test_dispatch_external_override_predicate():
         pass
 
     @App.predicate(App.f, name="model", default=None, index=ClassIndex)
-    def f_obj(app, obj):
+    def f_obj(app: App, obj: object) -> type[Any]:
         return obj.__class__
 
     @Sub.predicate(App.f, name="model", default=None, index=ClassIndex)
-    def f_obj_sub(app, obj):
+    def f_obj_sub(app: Sub, obj: object) -> type[Bar]:
         return Bar  # ridiculous, but lets us test this
 
     @App.predicate_fallback(App.f, f_obj)
-    def f_obj_fallback(app, obj):
+    def f_obj_fallback(app: App, obj: object) -> str:
         return "f_obj_fallback"
 
     @App.method(App.f, model=Foo)
-    def f_foo(app, obj):
+    def f_foo(app: App, obj: Foo) -> str:
         return "foo"
 
     @Sub.method(App.f, model=Foo)
-    def f_foo_sub(app, obj):
+    def f_foo_sub(app: Sub, obj: Foo) -> str:
         return "foo"
 
     @App.method(App.f, model=Bar)
-    def f_bar(app, obj):
+    def f_bar(app: App, obj: Bar) -> str:
         return "bar"
 
     @Sub.method(App.f, model=Bar)
-    def f_bar_sub(app, obj):
+    def f_bar_sub(app: Sub, obj: Bar) -> str:
         return "bar sub"
 
     s = Sub()
@@ -353,17 +357,17 @@ def test_dispatch_external_override_predicate():
     assert a.f(Other()) == "f_obj_fallback"
 
 
-def test_wrong_predicate_arguments_single():
+def test_wrong_predicate_arguments_single() -> None:
     class App(morepath.App):
         @morepath.dispatch_method("obj")
-        def f(self, obj):
+        def f(self, obj: Any) -> str:
             return "fallback"
 
     class Foo:
         pass
 
     @App.method(App.f, wrong=Foo)
-    def f_foo(app, obj):
+    def f_foo(app: App, obj: object) -> str:
         return "foo"
 
     a = App()
@@ -371,17 +375,17 @@ def test_wrong_predicate_arguments_single():
     assert a.f(Foo()) == "fallback"
 
 
-def test_wrong_predicate_arguments_multi():
+def test_wrong_predicate_arguments_multi() -> None:
     class App(morepath.App):
         @morepath.dispatch_method("a", "b")
-        def f(self, a, b):
+        def f(self, a: Any, b: Any) -> str:
             return "fallback"
 
     class Foo:
         pass
 
     @App.method(App.f, wrong=Foo)
-    def f_foo(app, a, b):
+    def f_foo(app: App, a: object, b: object) -> str:
         return "foo"
 
     a = App()
@@ -389,10 +393,10 @@ def test_wrong_predicate_arguments_multi():
     assert a.f(Foo(), Foo()) == "fallback"
 
 
-def test_dispatch_external_predicates_without_predicate_directives():
+def test_dispatch_external_predicates_without_predicate_directives() -> None:
     class App(morepath.App):
         @morepath.dispatch_method()
-        def f(self, obj):
+        def f(self, obj: Any) -> str:
             return "fallback"
 
     class Foo:
@@ -405,7 +409,7 @@ def test_dispatch_external_predicates_without_predicate_directives():
         pass
 
     @App.method(App.f)
-    def f_foo(app, obj):
+    def f_foo(app: App, obj: object) -> str:
         return "foo"
 
     a = App()

--- a/morepath/tests/test_predicates.py
+++ b/morepath/tests/test_predicates.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any
+
 from webtest import TestApp as Client
 
 import morepath
@@ -5,7 +9,7 @@ from morepath.app import App
 from reg import KeyIndex
 
 
-def test_view_predicates():
+def test_view_predicates() -> None:
     class app(App):
         pass
 
@@ -14,11 +18,11 @@ def test_view_predicates():
         pass
 
     @app.view(model=Root, name="foo", request_method="GET")
-    def get(self, request):
+    def get(self: Root, request: morepath.Request) -> str:
         return "GET"
 
     @app.view(model=Root, name="foo", request_method="POST")
-    def post(self, request):
+    def post(self: Root, request: morepath.Request) -> str:
         return "POST"
 
     c = Client(app())
@@ -29,21 +33,21 @@ def test_view_predicates():
     assert response.body == b"POST"
 
 
-def test_extra_predicates():
+def test_extra_predicates() -> None:
     class app(App):
         pass
 
     @app.path(path="{id}")
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     @app.view(model=Model, name="foo", id="a")
-    def get_a(self, request):
+    def get_a(self: Model, request: morepath.Request) -> str:
         return "a"
 
     @app.view(model=Model, name="foo", id="b")
-    def get_b(self, request):
+    def get_b(self: Model, request: morepath.Request) -> str:
         return "b"
 
     @app.predicate(
@@ -53,7 +57,7 @@ def test_extra_predicates():
         index=KeyIndex,
         after=morepath.request_method_predicate,
     )
-    def id_predicate(self, obj, request):
+    def id_predicate(self: app, obj: Any, request: morepath.Request) -> Any:
         return obj.id
 
     c = Client(app())

--- a/morepath/tests/test_publish.py
+++ b/morepath/tests/test_publish.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 import pytest
 import webob
 from webob.exc import HTTPBadRequest, HTTPFound, HTTPNotFound, HTTPOk
@@ -10,8 +14,13 @@ from morepath.publish import publish, resolve_response
 from morepath.request import Response
 from morepath.view import View, render_html, render_json
 
+if TYPE_CHECKING:
+    from webob import Response as BaseResponse
 
-def get_environ(path, **kw):
+    from morepath.types import WSGIEnvironment
+
+
+def get_environ(path: str, **kw: Any) -> WSGIEnvironment:
     return webob.Request.blank(path, **kw).environ
 
 
@@ -19,13 +28,13 @@ class Model:
     pass
 
 
-def test_view():
+def test_view() -> None:
     class app(App):
         pass
 
     dectate.commit(app)
 
-    def view(self, request):
+    def view(self: object, request: morepath.Request) -> str:
         return "View!"
 
     app.get_view.register(View(view), model=Model)
@@ -35,16 +44,16 @@ def test_view():
     assert result.body == b"View!"
 
 
-def test_predicates():
+def test_predicates() -> None:
     class app(App):
         pass
 
     dectate.commit(app)
 
-    def view(self, request):
+    def view(self: object, request: morepath.Request) -> str:
         return "all"
 
-    def post_view(self, request):
+    def post_view(self: object, request: morepath.Request) -> str:
         return "post"
 
     app.get_view.register(View(view), model=Model)
@@ -63,7 +72,7 @@ def test_predicates():
     )
 
 
-def test_notfound():
+def test_notfound() -> None:
     class app(App):
         pass
 
@@ -75,13 +84,13 @@ def test_notfound():
         publish(request)
 
 
-def test_notfound_with_predicates():
+def test_notfound_with_predicates() -> None:
     class app(morepath.App):
         pass
 
     dectate.commit(app)
 
-    def view(self, request):
+    def view(self: object, request: morepath.Request) -> str:
         return "view"
 
     app.get_view.register(View(view), model=Model)
@@ -93,13 +102,13 @@ def test_notfound_with_predicates():
         resolve_response(model, request)
 
 
-def test_response_returned():
+def test_response_returned() -> None:
     class app(morepath.App):
         pass
 
     dectate.commit(app)
 
-    def view(self, request):
+    def view(self: object, request: morepath.Request) -> Response:
         return Response("Hello world!")
 
     app.get_view.register(View(view), model=Model)
@@ -109,13 +118,13 @@ def test_response_returned():
     assert response.body == b"Hello world!"
 
 
-def test_request_view():
+def test_request_view() -> None:
     class app(morepath.App):
         pass
 
     dectate.commit(app)
 
-    def view(self, request):
+    def view(self: object, request: morepath.Request) -> dict[str, str]:
         return {"hey": "hey"}
 
     app.get_view.register(View(view, render=render_json), model=Model)
@@ -131,13 +140,13 @@ def test_request_view():
     assert request.view(model) == {"hey": "hey"}
 
 
-def test_request_view_with_predicates():
+def test_request_view_with_predicates() -> None:
     class app(morepath.App):
         pass
 
     dectate.commit(app)
 
-    def view(self, request):
+    def view(self: object, request: morepath.Request) -> dict[str, str]:
         return {"hey": "hey"}
 
     app.get_view.register(
@@ -157,13 +166,13 @@ def test_request_view_with_predicates():
     assert request.view(model) is None
 
 
-def test_render_html():
+def test_render_html() -> None:
     class app(App):
         pass
 
     dectate.commit(app)
 
-    def view(self, request):
+    def view(self: object, request: morepath.Request) -> str:
         return "<p>Hello world!</p>"
 
     app.get_view.register(View(view, render=render_html), model=Model)
@@ -175,13 +184,13 @@ def test_render_html():
     assert response.content_type == "text/html"
 
 
-def test_view_raises_http_error():
+def test_view_raises_http_error() -> None:
     class app(morepath.App):
         pass
 
     dectate.commit(app)
 
-    def view(self, request):
+    def view(self: object, request: morepath.Request) -> None:
         raise HTTPBadRequest()
 
     path_registry = app.config.path_registry
@@ -198,15 +207,15 @@ def test_view_raises_http_error():
         publish(request)
 
 
-def test_view_after():
+def test_view_after() -> None:
     class app(morepath.App):
         pass
 
     dectate.commit(app)
 
-    def view(self, request):
+    def view(self: object, request: morepath.Request) -> str:
         @request.after
-        def set_header(response):
+        def set_header(response: Response) -> None:
             response.headers.add("Foo", "FOO")
 
         return "View!"
@@ -219,15 +228,15 @@ def test_view_after():
     assert result.headers.get("Foo") == "FOO"
 
 
-def test_view_after_redirect():
+def test_view_after_redirect() -> None:
     class app(morepath.App):
         pass
 
     dectate.commit(app)
 
-    def view(self, request):
+    def view(self: object, request: morepath.Request) -> BaseResponse:
         @request.after
-        def set_header(response):
+        def set_header(response: BaseResponse) -> None:
             response.headers.add("Foo", "FOO")
 
         return morepath.redirect("http://example.org")
@@ -241,17 +250,17 @@ def test_view_after_redirect():
     assert result.headers.get("Foo") == "FOO"
 
 
-def test_conditional_view_after():
+def test_conditional_view_after() -> None:
     class app(morepath.App):
         pass
 
     dectate.commit(app)
 
-    def view(self, request):
+    def view(self: object, request: morepath.Request) -> str:
         if False:
 
-            @request.after
-            def set_header(response):
+            @request.after  # type: ignore[unreachable]
+            def set_header(response: Response) -> None:
                 response.headers.add("Foo", "FOO")
 
         return "View!"
@@ -264,16 +273,16 @@ def test_conditional_view_after():
     assert result.headers.get("Foo") is None
 
 
-def test_view_after_non_decorator():
+def test_view_after_non_decorator() -> None:
     class app(morepath.App):
         pass
 
     dectate.commit(app)
 
-    def set_header(response):
+    def set_header(response: Response) -> None:
         response.headers.add("Foo", "FOO")
 
-    def view(self, request):
+    def view(self: object, request: morepath.Request) -> str:
         request.after(set_header)
         return "View!"
 
@@ -285,7 +294,7 @@ def test_view_after_non_decorator():
     assert result.headers.get("Foo") == "FOO"
 
 
-def test_view_after_doesnt_apply_to_raised_404_exception():
+def test_view_after_doesnt_apply_to_raised_404_exception() -> None:
     class App(morepath.App):
         pass
 
@@ -293,13 +302,13 @@ def test_view_after_doesnt_apply_to_raised_404_exception():
         pass
 
     @App.path(model=Root, path="")
-    def get_root():
+    def get_root() -> Root:
         return Root()
 
     @App.view(model=Root)
-    def view(self, request):
+    def view(self: Root, request: morepath.Request) -> None:
         @request.after
-        def set_header(response):
+        def set_header(response: BaseResponse) -> None:
             response.headers.add("Foo", "FOO")
 
         raise HTTPNotFound()
@@ -312,7 +321,7 @@ def test_view_after_doesnt_apply_to_raised_404_exception():
     assert response.headers.get("Foo") is None
 
 
-def test_view_after_doesnt_apply_to_returned_404_exception():
+def test_view_after_doesnt_apply_to_returned_404_exception() -> None:
     class App(morepath.App):
         pass
 
@@ -320,13 +329,13 @@ def test_view_after_doesnt_apply_to_returned_404_exception():
         pass
 
     @App.path(model=Root, path="")
-    def get_root():
+    def get_root() -> Root:
         return Root()
 
     @App.view(model=Root)
-    def view(self, request):
+    def view(self: Root, request: morepath.Request) -> HTTPNotFound:
         @request.after
-        def set_header(response):
+        def set_header(response: BaseResponse) -> None:
             response.headers.add("Foo", "FOO")
 
         return HTTPNotFound()
@@ -342,7 +351,9 @@ def test_view_after_doesnt_apply_to_returned_404_exception():
 @pytest.mark.parametrize(
     "status_code,exception_class", [(200, HTTPOk), (302, HTTPFound)]
 )
-def test_view_after_applies_to_some_exceptions(status_code, exception_class):
+def test_view_after_applies_to_some_exceptions(
+    status_code: int, exception_class: type[Exception]
+) -> None:
     class App(morepath.App):
         pass
 
@@ -350,13 +361,13 @@ def test_view_after_applies_to_some_exceptions(status_code, exception_class):
         pass
 
     @App.path(model=Root, path="")
-    def get_root():
+    def get_root() -> Root:
         return Root()
 
     @App.view(model=Root)
-    def view(self, request):
+    def view(self: Root, request: morepath.Request) -> None:
         @request.after
-        def set_header(response):
+        def set_header(response: BaseResponse) -> None:
             response.headers.add("Foo", "FOO")
 
         raise exception_class()
@@ -369,7 +380,7 @@ def test_view_after_applies_to_some_exceptions(status_code, exception_class):
     assert response.headers.get("Foo") == "FOO"
 
 
-def test_view_after_doesnt_apply_to_exception_view():
+def test_view_after_doesnt_apply_to_exception_view() -> None:
     class App(morepath.App):
         pass
 
@@ -380,19 +391,19 @@ def test_view_after_doesnt_apply_to_exception_view():
         pass
 
     @App.path(model=Root, path="")
-    def get_root():
+    def get_root() -> Root:
         return Root()
 
     @App.view(model=Root)
-    def view(self, request):
+    def view(self: Root, request: morepath.Request) -> None:
         @request.after
-        def set_header(response):
+        def set_header(response: BaseResponse) -> None:
             response.headers.add("Foo", "FOO")
 
         raise MyException()
 
     @App.view(model=MyException)
-    def exc_view(self, request):
+    def exc_view(self: MyException, request: morepath.Request) -> str:
         return "My exception"
 
     dectate.commit(App)

--- a/morepath/tests/test_querytool.py
+++ b/morepath/tests/test_querytool.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 import dectate
 import morepath
 import reg
@@ -5,24 +9,27 @@ from morepath import core
 
 from .fixtures import identity_policy
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
-def objects(actions):
+
+def objects(actions: Iterable[tuple[dectate.Action, Any]]) -> list[Any]:
     result = []
     for action, obj in actions:
         result.append(obj)
     return result
 
 
-def test_setting():
+def test_setting() -> None:
     class App(morepath.App):
         pass
 
     @App.setting(section="foo", name="bar")
-    def f():
+    def f() -> str:
         return "Hello"
 
     @App.setting(section="foo", name="qux")
-    def g():
+    def g() -> str:
         return "Dag"
 
     dectate.commit(App)
@@ -34,7 +41,7 @@ def test_setting():
     assert objects(dectate.query_app(App, "setting_section")) == [f, g]
 
 
-def test_predicate_fallback():
+def test_predicate_fallback() -> None:
     class App(morepath.App):
         pass
 
@@ -76,7 +83,7 @@ def test_predicate_fallback():
     ]
 
 
-def test_predicate():
+def test_predicate() -> None:
     class App(morepath.App):
         pass
 
@@ -122,21 +129,21 @@ def test_predicate():
 
 class App(morepath.App):
     @morepath.dispatch_method()
-    def generic(self, v):
+    def generic(self, v: str) -> str | None:
         pass
 
 
-def test_method():
+def test_method() -> None:
     @App.predicate(App.generic, name="v", default="", index=reg.KeyIndex)
-    def get(self, v):
+    def get(self: App, v: str) -> str:
         return v
 
     @App.method(App.generic, v="A")
-    def a(app, v):
+    def a(app: App, v: str) -> str:
         return v
 
     @App.method(App.generic, v="B")
-    def b(app, v):
+    def b(app: App, v: str) -> str:
         return v
 
     dectate.commit(App)
@@ -162,7 +169,7 @@ def test_method():
     assert r == [a]
 
 
-def test_converter():
+def test_converter() -> None:
     class App(morepath.App):
         pass
 
@@ -205,30 +212,30 @@ class SubBar(Bar):
     pass
 
 
-def get_variables(obj):
-    pass
-
-
-def get_converters():
+def get_variables(obj: Any) -> dict[str, Any]:
     return {}
 
 
-def test_path():
+def get_converters() -> dict[str, Any]:
+    return {}
+
+
+def test_path() -> None:
     class App(morepath.App):
         pass
 
     @App.path("base", model=Base)
-    def get_base():
+    def get_base() -> None:
         pass
 
     @App.path("foos", model=Foos, variables=get_variables)
-    def get_foos():
+    def get_foos() -> None:
         pass
 
     @App.path(
         "foos/{id}", model=Foo, get_converters=get_converters, absorb=True
     )
-    def get_foo(id):
+    def get_foo(id: str) -> None:
         pass
 
     dectate.commit(App)
@@ -323,22 +330,22 @@ class SubIdentity(morepath.Identity):
     pass
 
 
-def test_permission_rule():
+def test_permission_rule() -> None:
     class App(morepath.App):
         pass
 
     @App.permission_rule(model=Base, permission=BasePermission)
-    def rule_base(obj, permission, identity):
+    def rule_base(obj: Base, permission: object, identity: object) -> bool:
         return True
 
     @App.permission_rule(model=Foo, permission=Permission)
-    def rule_foo(obj, permission, identity):
+    def rule_foo(obj: Foo, permission: object, identity: object) -> bool:
         return True
 
     @App.permission_rule(
         model=Foos, permission=SubPermission, identity=SubIdentity
     )
-    def rule_foos(obj, permission, identity):
+    def rule_foos(obj: Foos, permission: object, identity: object) -> bool:
         return True
 
     dectate.commit(App)
@@ -429,11 +436,11 @@ def test_permission_rule():
     assert r == [rule_foos]
 
 
-def template_directory_a():
+def template_directory_a() -> str:
     return "/"
 
 
-def test_template_directory():
+def test_template_directory() -> None:
     class App(morepath.App):
         pass
 
@@ -441,7 +448,7 @@ def test_template_directory():
     App.template_directory()(template_directory_a)
 
     @App.template_directory(after=template_directory_a, name="blah")
-    def b():
+    def b() -> str:
         return "/"
 
     dectate.commit(App)
@@ -464,16 +471,16 @@ def test_template_directory():
     assert r == [b]
 
 
-def test_template_render():
+def test_template_render() -> None:
     class App(morepath.App):
         pass
 
     @App.template_render(".zpt")
-    def render(loader, name, original_render):
+    def render(loader: object, name: str, original_render: object) -> None:
         pass
 
     @App.template_render(".blah")
-    def render2(loader, name, original_render):
+    def render2(loader: object, name: str, original_render: object) -> None:
         pass
 
     dectate.commit(App)
@@ -487,20 +494,20 @@ def test_template_render():
     assert r == [render2]
 
 
-def test_view():
+def test_view() -> None:
     class App(morepath.App):
         pass
 
     @App.json(model=Foo)
-    def foo_default(self, request):
+    def foo_default(self: Foo, request: morepath.Request) -> None:
         pass
 
     @App.view(model=Base)
-    def base_default(self, request):
+    def base_default(self: Base, request: morepath.Request) -> None:
         pass
 
     @App.view(model=Foo, name="edit")
-    def foo_edit(self, request):
+    def foo_edit(self: Foo, request: morepath.Request) -> None:
         pass
 
     dectate.commit(App)
@@ -552,24 +559,24 @@ def test_view():
     assert r == [foo_edit]
 
 
-def test_view_permission():
+def test_view_permission() -> None:
     class App(morepath.App):
         pass
 
     @App.view(model=Foo, name="n")
-    def foo_n(self, request):
+    def foo_n(self: Foo, request: morepath.Request) -> None:
         pass
 
     @App.view(model=Foo, name="b", permission=BasePermission)
-    def foo_b(self, request):
+    def foo_b(self: Foo, request: morepath.Request) -> None:
         pass
 
     @App.view(model=Foo, name="p", permission=Permission)
-    def foo_p(self, request):
+    def foo_p(self: Foo, request: morepath.Request) -> None:
         pass
 
     @App.view(model=Foo, name="s", permission=SubPermission)
-    def foo_s(self, request):
+    def foo_s(self: Foo, request: morepath.Request) -> None:
         pass
 
     dectate.commit(App)
@@ -618,16 +625,16 @@ class Mounted(morepath.App):
     pass
 
 
-def test_mount():
+def test_mount() -> None:
     class App(morepath.App):
         pass
 
     @App.path(path="foo", model=Foo)
-    def get_foo():
+    def get_foo() -> None:
         pass
 
     @App.mount(path="mounted", app=Mounted)
-    def mount_app():
+    def mount_app() -> Mounted:
         return Mounted()
 
     dectate.commit(App, Mounted)
@@ -653,7 +660,7 @@ def test_mount():
     assert r == [get_foo]
 
 
-def test_defer_links():
+def test_defer_links() -> None:
     class App(morepath.App):
         pass
 
@@ -661,15 +668,15 @@ def test_defer_links():
         pass
 
     @App.path(path="foo", model=Foo)
-    def get_foo():
+    def get_foo() -> None:
         pass
 
     @App.defer_links(model=Bar)
-    def defer_bar(app, obj):
+    def defer_bar(app: App, obj: Bar) -> morepath.App | None:
         return app.child("mounted")
 
     @App.mount(path="mounted", app=Mounted2)
-    def mount_app():
+    def mount_app() -> Mounted2:
         return Mounted2()
 
     dectate.commit(App, Mounted2)
@@ -702,15 +709,19 @@ def test_defer_links():
     assert r == [get_foo]
 
 
-def tween_a_factory():
-    pass
+if TYPE_CHECKING:
+    tween_a_factory: Any
+    tween_b_factory: Any
+else:
+
+    def tween_a_factory():
+        pass
+
+    def tween_b_factory():
+        pass
 
 
-def tween_b_factory():
-    pass
-
-
-def test_tween_factory():
+def test_tween_factory() -> None:
     class App(morepath.App):
         pass
 
@@ -739,12 +750,12 @@ def test_tween_factory():
     assert r == [tween_b_factory]
 
 
-def test_identity_policy():
+def test_identity_policy() -> None:
     class App(morepath.App):
         pass
 
     @App.identity_policy()
-    def get_identity_policy():
+    def get_identity_policy() -> identity_policy.IdentityPolicy:
         return identity_policy.IdentityPolicy()
 
     dectate.commit(App)
@@ -754,12 +765,12 @@ def test_identity_policy():
     assert len(r) == 1
 
 
-def test_verify_identity():
+def test_verify_identity() -> None:
     class App(morepath.App):
         pass
 
     @App.verify_identity()
-    def verify(identity):
+    def verify(identity: morepath.Identity) -> bool:
         return True
 
     dectate.commit(App)
@@ -769,16 +780,16 @@ def test_verify_identity():
     assert r == [verify]
 
 
-def test_dump_json():
+def test_dump_json() -> None:
     class App(morepath.App):
         pass
 
     @App.dump_json(model=Foo)
-    def dump_foo(self, request):
+    def dump_foo(self: Foo, request: morepath.Request) -> None:
         pass
 
     @App.dump_json(model=Bar)
-    def dump_bar(self, request):
+    def dump_bar(self: Bar, request: morepath.Request) -> None:
         pass
 
     dectate.commit(App)
@@ -804,12 +815,12 @@ def test_dump_json():
     assert r == [dump_foo]
 
 
-def test_link_prefix():
+def test_link_prefix() -> None:
     class App(morepath.App):
         pass
 
     @App.link_prefix()
-    def prefix(s):
+    def prefix(s: App) -> None:
         pass
 
     dectate.commit(App)

--- a/morepath/tests/test_reify.py
+++ b/morepath/tests/test_reify.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 from morepath import reify
 
 # from pyramid.tests.test_decorator
 
 
-def test__get__with_inst():
-    def wrapped(inst):
+def test__get__with_inst() -> None:
+    def wrapped(inst: object) -> str:
         return "a"
 
     decorator = reify(wrapped)
@@ -14,22 +16,22 @@ def test__get__with_inst():
     assert inst.__dict__["wrapped"] == "a"
 
 
-def test__get__noinst():
-    decorator = reify(None)
+def test__get__noinst() -> None:
+    decorator = reify(None)  # type: ignore
     result = decorator.__get__(None)
     assert result is decorator
 
 
-def test__doc__copied():
-    def wrapped(inst):
+def test__doc__copied() -> None:
+    def wrapped(inst: object) -> None:
         """My doc"""
 
     decorator = reify(wrapped)
     assert decorator.__doc__ == "My doc"
 
 
-def test_no_doc():
-    def wrapped(inst):
+def test_no_doc() -> None:
+    def wrapped(inst: object) -> None:
         pass
 
     decorator = reify(wrapped)

--- a/morepath/tests/test_request.py
+++ b/morepath/tests/test_request.py
@@ -1,9 +1,19 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from webtest import TestApp as Client
 
 from morepath import App, render_json
 
+if TYPE_CHECKING:
+    from webob import Response as BaseResponse
 
-def test_request_reset():
+    from morepath import Request
+    from morepath.types import Tween
+
+
+def test_request_reset() -> None:
     # In order to  verify the behaviour of Request.reset  we issue the
     # same request three times:
     #
@@ -24,8 +34,8 @@ def test_request_reset():
         pass
 
     @RootApp.tween_factory()
-    def report_error(app, handler):
-        def tween(request):
+    def report_error(app: RootApp, handler: Tween) -> Tween:
+        def tween(request: Request) -> BaseResponse:
             try:
                 response = handler(request)
                 response.headers["Tween-Header"] = "FOO"
@@ -53,7 +63,7 @@ def test_request_reset():
         pass
 
     @MountedApp.view(model=Catalog, name="text")
-    def view_catalog(self, request):
+    def view_catalog(self: Catalog, request: Request) -> str:
         if generate_error:
             raise RuntimeError("Error!")
         return "The catalog"

--- a/morepath/tests/test_run.py
+++ b/morepath/tests/test_run.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import errno
 import re
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -7,8 +10,16 @@ import morepath
 
 from .fixtures import basic
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from wsgiref.simple_server import WSGIServer
 
-def test_run_port_out_of_range(mockserver, capsys):
+    from .conftest import MockServer
+
+
+def test_run_port_out_of_range(
+    mockserver: MockServer, capsys: pytest.CaptureFixture[str]
+) -> None:
     "Fail gracefully if the port is out of range."
     mockserver.set_argv(["--port", "-3"])
 
@@ -16,17 +27,16 @@ def test_run_port_out_of_range(mockserver, capsys):
 
     out, err = capsys.readouterr()
 
-    assert (
-        err
-        == """\
+    assert err == """\
 usage: script-name [-h] [-p PORT] [-H HOST]
 script-name: error: argument -p/--port: invalid integer in 0..65535 value: '-3'
 """
-    )
     assert out == ""
 
 
-def test_run_socketerror(mockserver, capsys):
+def test_run_socketerror(
+    mockserver: MockServer, capsys: pytest.CaptureFixture[str]
+) -> None:
     """Fail gracefully on a socket error.
 
     In this case the error is triggered by listening on example.com.
@@ -43,7 +53,9 @@ def test_run_socketerror(mockserver, capsys):
     assert out == ""
 
 
-def test_run_defaults(mockserver, capsys):
+def test_run_defaults(
+    mockserver: MockServer, capsys: pytest.CaptureFixture[str]
+) -> None:
     "The arguments to makeserver form the defaults for the CLI."
     mockserver.set_argv(["script-name", "--help"])
 
@@ -84,7 +96,9 @@ options:
         assert re.match(expected_pattern, out, re.DOTALL)
 
 
-def test_run(mockserver, capsys):
+def test_run(
+    mockserver: MockServer, capsys: pytest.CaptureFixture[str]
+) -> None:
     "Run with a mocked server."
     mockserver.set_argv(["--port", "0"])
 
@@ -104,7 +118,9 @@ Received keyboard interrupt.""",
     )
 
 
-def test_run_hint_on_eaddrinuse(mockserver, capsys):
+def test_run_hint_on_eaddrinuse(
+    mockserver: MockServer, capsys: pytest.CaptureFixture[str]
+) -> None:
     """Fail not only gracefully but also helpfully on EADDRINUSE.
 
     In this case having a second server (mockserver) listening on the
@@ -112,7 +128,7 @@ def test_run_hint_on_eaddrinuse(mockserver, capsys):
 
     """
 
-    def with_existing(first_server):
+    def with_existing(first_server: WSGIServer) -> None:
         used_port = first_server.server_port
         # setup a second server on exactly the same port
         mockserver.set_argv(["--port", str(used_port)])
@@ -126,9 +142,7 @@ script-name: .*: 127.0.0.1:{}
 
   Use '--port PORT' to specify a different port.
 
-""".format(
-            used_port
-        )
+""".format(used_port)
 
         assert re.match(rex, err)
         assert out == ""
@@ -157,14 +171,16 @@ script-name: .*: 127.0.0.1:{}
     assert ex.value.code == 0
 
 
-def test_run_actual(capsys):
+def test_run_actual(capsys: pytest.CaptureFixture[str]) -> None:
     from threading import Thread
 
-    def query(url, completion_callback, response):
-        try:
-            from urllib import urlopen
-        except ImportError:
-            from urllib.request import urlopen
+    def query(
+        url: str,
+        completion_callback: Callable[[], object],
+        response: list[Exception | bytes],
+    ) -> None:
+        from urllib.request import urlopen
+
         try:
             response.append(urlopen(url).read())
         except Exception as ex:
@@ -172,9 +188,9 @@ def test_run_actual(capsys):
         finally:
             completion_callback()
 
-    response = []
+    response: list[Exception | bytes] = []
 
-    def callback(server):
+    def callback(server: WSGIServer) -> None:
         thread = Thread(
             target=query,
             args=(

--- a/morepath/tests/test_scanning.py
+++ b/morepath/tests/test_scanning.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from webtest import TestApp as Client
 
@@ -6,7 +8,7 @@ import morepath
 from .fixtures import basic, pkg, self_scan
 
 
-def test_rescan():
+def test_rescan() -> None:
     morepath.scan(basic)
 
     assert basic.app.commit() == {basic.app}
@@ -17,7 +19,7 @@ def test_rescan():
         pass
 
     @Sub.view(model=basic.Model, name="extra")
-    def extra(self, request):
+    def extra(self: basic.Model, request: morepath.Request) -> str:
         return "extra"
 
     assert Sub.commit() == {Sub}
@@ -31,16 +33,16 @@ def test_rescan():
     assert response.body == b"The view for model: 1"
 
 
-def test_scanned_some_error():
+def test_scanned_some_error() -> None:
     with pytest.raises(ZeroDivisionError):
         morepath.scan(pkg)
 
 
-def test_caller_package_in_init():
+def test_caller_package_in_init() -> None:
     assert self_scan.get_this_package() == self_scan
 
 
-def test_self_scanning_package():
+def test_self_scanning_package() -> None:
     from .fixtures.self_scan.app import App
 
     # Importing the app as we did above imports the definition only,

--- a/morepath/tests/test_scenario.py
+++ b/morepath/tests/test_scenario.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from webtest import TestApp as Client
 
 import morepath
@@ -6,7 +8,7 @@ from .fixtures import scenario
 from .fixtures.scenario import app
 
 
-def test_scenario():
+def test_scenario() -> None:
     morepath.scan(scenario)
 
     c = Client(app.Root())

--- a/morepath/tests/test_security.py
+++ b/morepath/tests/test_security.py
@@ -1,26 +1,28 @@
+from __future__ import annotations
+
 import base64
 import json
+from http.cookiejar import CookieJar
+from typing import TYPE_CHECKING, Any
 
 from webtest import TestApp as Client
 
 import morepath
-from morepath.authentication import NO_IDENTITY, Identity
+from morepath.authentication import NO_IDENTITY, Identity, NoIdentity
 from morepath.request import Response
 
 from .fixtures import identity_policy
 
-try:
-    from cookielib import CookieJar
-except ImportError:
-    from http.cookiejar import CookieJar
+if TYPE_CHECKING:
+    from morepath.settings import SettingRegistry
 
 
-def test_no_permission():
+def test_no_permission() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     class Permission:
@@ -29,11 +31,11 @@ def test_no_permission():
     @app.path(
         model=Model, path="{id}", variables=lambda model: {"id": model.id}
     )
-    def get_model(id):
+    def get_model(id: str) -> Model:
         return Model(id)
 
     @app.view(model=Model, permission=Permission)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "Model: %s" % self.id
 
     c = Client(app())
@@ -41,47 +43,51 @@ def test_no_permission():
     c.get("/foo", status=403)
 
 
-def test_permission_directive_identity():
+def test_permission_directive_identity() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     class Permission:
         pass
 
     @app.verify_identity()
-    def verify_identity(identity):
+    def verify_identity(identity: object) -> bool:
         return True
 
     @app.path(
         model=Model, path="{id}", variables=lambda model: {"id": model.id}
     )
-    def get_model(id):
+    def get_model(id: str) -> Model:
         return Model(id)
 
     @app.permission_rule(model=Model, permission=Permission)
-    def get_permission(identity, model, permission):
+    def get_permission(
+        identity: object, model: Model, permission: object
+    ) -> bool:
         if model.id == "foo":
             return True
         else:
             return False
 
     @app.view(model=Model, permission=Permission)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "Model: %s" % self.id
 
     @app.identity_policy()
     class IdentityPolicy:
-        def identify(self, request):
+        def identify(self, request: object) -> Identity:
             return Identity("testidentity")
 
-        def remember(self, response, request, identity):
+        def remember(
+            self, response: object, request: object, identity: object
+        ) -> None:
             pass
 
-        def forget(self, response, request):
+        def forget(self, response: object, request: object) -> None:
             pass
 
     c = Client(app())
@@ -91,29 +97,31 @@ def test_permission_directive_identity():
     response = c.get("/bar", status=403)
 
 
-def test_permission_directive_with_app_arg():
+def test_permission_directive_with_app_arg() -> None:
     class App(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     class Permission:
         pass
 
     @App.verify_identity()
-    def verify_identity(identity):
+    def verify_identity(identity: object) -> bool:
         return True
 
     @App.path(
         model=Model, path="{id}", variables=lambda model: {"id": model.id}
     )
-    def get_model(id):
+    def get_model(id: str) -> Model:
         return Model(id)
 
     @App.permission_rule(model=Model, permission=Permission)
-    def get_permission(app, identity, model, permission):
+    def get_permission(
+        app: App, identity: object, model: Model, permission: object
+    ) -> bool:
         assert isinstance(app, App)
         if model.id == "foo":
             return True
@@ -121,18 +129,20 @@ def test_permission_directive_with_app_arg():
             return False
 
     @App.view(model=Model, permission=Permission)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "Model: %s" % self.id
 
     @App.identity_policy()
     class IdentityPolicy:
-        def identify(self, request):
+        def identify(self, request: object) -> Identity:
             return Identity("testidentity")
 
-        def remember(self, response, request, identity):
+        def remember(
+            self, response: object, request: object, identity: object
+        ) -> None:
             pass
 
-        def forget(self, response, request):
+        def forget(self, response: object, request: object) -> None:
             pass
 
     c = Client(App())
@@ -142,12 +152,12 @@ def test_permission_directive_with_app_arg():
     response = c.get("/bar", status=403)
 
 
-def test_permission_directive_no_identity():
+def test_permission_directive_no_identity() -> None:
     class app(morepath.App):
         pass
 
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     class Permission:
@@ -156,18 +166,20 @@ def test_permission_directive_no_identity():
     @app.path(
         model=Model, path="{id}", variables=lambda model: {"id": model.id}
     )
-    def get_model(id):
+    def get_model(id: str) -> Model:
         return Model(id)
 
     @app.permission_rule(model=Model, permission=Permission, identity=None)
-    def get_permission(identity, model, permission):
+    def get_permission(
+        identity: object, model: Model, permission: object
+    ) -> bool:
         if model.id == "foo":
             return True
         else:
             return False
 
     @app.view(model=Model, permission=Permission)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "Model: %s" % self.id
 
     c = Client(app())
@@ -177,7 +189,7 @@ def test_permission_directive_no_identity():
     response = c.get("/bar", status=403)
 
 
-def test_policy_action():
+def test_policy_action() -> None:
     c = Client(identity_policy.app())
 
     response = c.get("/foo")
@@ -185,24 +197,24 @@ def test_policy_action():
     response = c.get("/bar", status=403)
 
 
-def test_no_identity_policy():
+def test_no_identity_policy() -> None:
     class App(morepath.App):
         pass
 
     @App.path(path="{id}")
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     class Permission:
         pass
 
     @App.view(model=Model, permission=Permission)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "Model: %s" % self.id
 
     @App.view(model=Model, name="log_in")
-    def log_in(self, request):
+    def log_in(self: Model, request: morepath.Request) -> Response:
         response = Response()
         request.app.remember_identity(
             response, request, Identity(userid="user", payload="Amazing")
@@ -210,13 +222,13 @@ def test_no_identity_policy():
         return response
 
     @App.view(model=Model, name="log_out")
-    def log_out(self, request):
+    def log_out(self: Model, request: morepath.Request) -> Response:
         response = Response()
         request.app.forget_identity(response, request)
         return response
 
     @App.verify_identity()
-    def verify_identity(identity):
+    def verify_identity(identity: object) -> bool:
         return True
 
     c = Client(App())
@@ -241,43 +253,47 @@ class DumbCookieIdentityPolicy:
     Only for testing. Don't use in practice!
     """
 
-    def identify(self, request):
+    def identify(self, request: morepath.Request) -> Identity | NoIdentity:
         data = request.cookies.get("dumb_id", None)
         if data is None:
             return NO_IDENTITY
         data = json.loads(base64.b64decode(data).decode())
         return Identity(**data)
 
-    def remember(self, response, request, identity):
+    def remember(
+        self, response: Response, request: morepath.Request, identity: Identity
+    ) -> None:
         data = base64.b64encode(str.encode(json.dumps(identity.as_dict())))
         response.set_cookie("dumb_id", data)
 
-    def forget(self, response, request):
+    def forget(self, response: Response, request: morepath.Request) -> None:
         response.delete_cookie("dumb_id")
 
 
-def test_cookie_identity_policy():
+def test_cookie_identity_policy() -> None:
     class app(morepath.App):
         pass
 
     @app.path(path="{id}")
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     class Permission:
         pass
 
     @app.permission_rule(model=Model, permission=Permission)
-    def get_permission(identity, model, permission):
+    def get_permission(
+        identity: Identity | NoIdentity, model: Model, permission: object
+    ) -> bool:
         return identity.userid == "user"
 
     @app.view(model=Model, permission=Permission)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "Model: %s" % self.id
 
     @app.view(model=Model, name="log_in")
-    def log_in(self, request):
+    def log_in(self: Model, request: morepath.Request) -> Response:
         response = Response()
         request.app.remember_identity(
             response, request, Identity(userid="user", payload="Amazing")
@@ -285,17 +301,17 @@ def test_cookie_identity_policy():
         return response
 
     @app.view(model=Model, name="log_out")
-    def log_out(self, request):
+    def log_out(self: Model, request: morepath.Request) -> Response:
         response = Response()
         request.app.forget_identity(response, request)
         return response
 
     @app.identity_policy()
-    def policy():
+    def policy() -> DumbCookieIdentityPolicy:
         return DumbCookieIdentityPolicy()
 
     @app.verify_identity()
-    def verify_identity(identity):
+    def verify_identity(identity: Identity) -> bool:
         return True
 
     c = Client(app(), cookiejar=CookieJar())
@@ -312,7 +328,7 @@ def test_cookie_identity_policy():
     response = c.get("/foo", status=403)
 
 
-def test_default_verify_identity():
+def test_default_verify_identity() -> None:
     class app(morepath.App):
         pass
 
@@ -321,13 +337,13 @@ def test_default_verify_identity():
     assert not app()._verify_identity(identity)
 
 
-def test_verify_identity_directive():
+def test_verify_identity_directive() -> None:
     class app(morepath.App):
         pass
 
     @app.verify_identity()
-    def verify_identity(identity):
-        return identity.password == "right"
+    def verify_identity(identity: Identity) -> bool:
+        return identity.password == "right"  # type: ignore[no-any-return]
 
     identity = morepath.Identity("foo", password="wrong")
     assert not app()._verify_identity(identity)
@@ -336,14 +352,14 @@ def test_verify_identity_directive():
     assert app()._verify_identity(identity)
 
 
-def test_verify_identity_directive_app_arg():
+def test_verify_identity_directive_app_arg() -> None:
     class App(morepath.App):
         pass
 
     @App.verify_identity()
-    def verify_identity(app, identity):
+    def verify_identity(app: App, identity: Identity) -> bool:
         assert isinstance(app, App)
-        return identity.password == "right"
+        return identity.password == "right"  # type: ignore[no-any-return]
 
     identity = morepath.Identity("foo", password="wrong")
     assert not App()._verify_identity(identity)
@@ -352,22 +368,22 @@ def test_verify_identity_directive_app_arg():
     assert App()._verify_identity(identity)
 
 
-def test_verify_identity_directive_identity_argument():
+def test_verify_identity_directive_identity_argument() -> None:
     class app(morepath.App):
         pass
 
     class PlainIdentity(morepath.Identity):
-        pass
+        password: str
 
     @app.verify_identity(identity=object)
-    def verify_identity(identity):
+    def verify_identity(identity: object) -> bool:
         return False
 
     @app.verify_identity(identity=PlainIdentity)
-    def verify_plain_identity(identity):
+    def verify_plain_identity(identity: PlainIdentity) -> bool:
         return identity.password == "right"
 
-    identity = PlainIdentity("foo", password="wrong")
+    identity: morepath.Identity = PlainIdentity("foo", password="wrong")
     assert not app()._verify_identity(identity)
     identity = morepath.Identity("foo", password="right")
     assert not app()._verify_identity(identity)
@@ -375,24 +391,24 @@ def test_verify_identity_directive_identity_argument():
     assert app()._verify_identity(identity)
 
 
-def test_false_verify_identity():
+def test_false_verify_identity() -> None:
     class app(morepath.App):
         pass
 
     @app.path(path="{id}")
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     class Permission:
         pass
 
     @app.view(model=Model, permission=Permission)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "Model: %s" % self.id
 
     @app.view(model=Model, name="log_in")
-    def log_in(self, request):
+    def log_in(self: Model, request: morepath.Request) -> Response:
         response = Response()
         request.app.remember_identity(
             response, request, Identity(userid="user", payload="Amazing")
@@ -400,11 +416,11 @@ def test_false_verify_identity():
         return response
 
     @app.identity_policy()
-    def policy():
+    def policy() -> DumbCookieIdentityPolicy:
         return DumbCookieIdentityPolicy()
 
     @app.verify_identity()
-    def verify_identity(identity):
+    def verify_identity(identity: Identity) -> bool:
         return False
 
     c = Client(app(), cookiejar=CookieJar())
@@ -416,7 +432,7 @@ def test_false_verify_identity():
     c.get("/foo", status=403)
 
 
-def test_dispatch_verify_identity():
+def test_dispatch_verify_identity() -> None:
     # This app uses two Identity classes, morepath.Identity and
     # Anonymous, which are verified in two different ways (see the two
     # functions a little further down that are decorated by
@@ -426,29 +442,31 @@ def test_dispatch_verify_identity():
 
     @App.path(path="{id}")
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     class Read:
         """Read Permission"""
 
     class Anonymous(Identity):
-        def __init__(self, **kw):
+        def __init__(self, **kw: Any) -> None:
             super().__init__(userid=None, **kw)
 
     @App.permission_rule(model=Model, permission=Read)
-    def get_permission(identity, model, permission):
+    def get_permission(
+        identity: object, model: Model, permission: object
+    ) -> bool:
         return True
 
     @App.view(model=Model, permission=Read)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         if request.identity.userid == self.id:
             return "Read restricted: %s" % self.id
         return "Read shared: %s" % self.id
 
     @App.identity_policy()
     class HeaderIdentityPolicy:
-        def identify(self, request):
+        def identify(self, request: morepath.Request) -> Identity | None:
             user = request.headers.get("user", None)
             if user is not None:
                 if user == "":
@@ -456,19 +474,22 @@ def test_dispatch_verify_identity():
                 return Identity(
                     userid=user, password=request.headers["password"]
                 )
+            return None
 
-        def remember(self, response, request, identity):
+        def remember(
+            self, response: object, request: object, identity: object
+        ) -> None:
             pass
 
-        def forget(self, response, request):
+        def forget(self, response: object, request: object) -> None:
             pass
 
     @App.verify_identity(identity=Identity)
-    def verify_identity(identity):
-        return identity.password == "secret"
+    def verify_identity(identity: Identity) -> bool:
+        return identity.password == "secret"  # type: ignore[no-any-return]
 
     @App.verify_identity(identity=Anonymous)
-    def verify_anonymous(identity):
+    def verify_anonymous(identity: Anonymous) -> bool:
         return True
 
     c = Client(App())
@@ -484,7 +505,7 @@ def test_dispatch_verify_identity():
     assert r.text == "Read shared: foo"
 
 
-def test_settings():
+def test_settings() -> None:
     class App(morepath.App):
         pass
 
@@ -492,31 +513,31 @@ def test_settings():
         pass
 
     @App.verify_identity()
-    def verify_identity(identity):
+    def verify_identity(identity: object) -> bool:
         return True
 
     @App.path(model=Model, path="test")
-    def get_model():
+    def get_model() -> Model:
         return Model()
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "%s, your token is valid." % request.identity.userid
 
     @App.setting_section(section="test")
-    def get_test_settings():
+    def get_test_settings() -> dict[str, str]:
         return {"encryption_key": "secret"}
 
     @App.identity_policy()
-    def get_identity_policy(settings):
+    def get_identity_policy(settings: SettingRegistry) -> IdentityPolicy:
         test_settings = settings.test.__dict__.copy()
         return IdentityPolicy(**test_settings)
 
     class IdentityPolicy:
-        def __init__(self, encryption_key):
+        def __init__(self, encryption_key: str) -> None:
             self.encryption_key = encryption_key
 
-        def identify(self, request):
+        def identify(self, request: morepath.Request) -> Identity | NoIdentity:
             token = self.get_token(request)
             if token is None or not self.token_is_valid(
                 token, self.encryption_key
@@ -524,22 +545,24 @@ def test_settings():
                 return NO_IDENTITY
             return Identity("Testuser")
 
-        def remember(self, response, request, identity):
+        def remember(
+            self, response: object, request: object, identity: object
+        ) -> None:
             pass
 
-        def forget(self, response, request):
+        def forget(self, response: object, request: object) -> None:
             pass
 
-        def get_token(self, request):
-            try:
-                authtype, token = request.authorization
-            except ValueError:
+        def get_token(self, request: morepath.Request) -> str | None:
+            if request.authorization is None:
                 return None
+            authtype, token = request.authorization
             if authtype.lower() != "bearer":
                 return None
+            assert isinstance(token, str)
             return token
 
-        def token_is_valid(self, token, encryption_key):
+        def token_is_valid(self, token: str, encryption_key: str) -> bool:
             return token == encryption_key  # fake validation
 
     c = Client(App())
@@ -549,7 +572,7 @@ def test_settings():
     assert response.body == b"Testuser, your token is valid."
 
 
-def test_prevent_poisoned_host_headers():
+def test_prevent_poisoned_host_headers() -> None:
     class App(morepath.App):
         pass
 
@@ -558,7 +581,7 @@ def test_prevent_poisoned_host_headers():
         pass
 
     @App.view(model=Model)
-    def view_model(self, request):
+    def view_model(self: Model, request: morepath.Request) -> str:
         return "ok"
 
     poisoned_hosts = (
@@ -592,45 +615,49 @@ def test_prevent_poisoned_host_headers():
         assert response.status_code == 400
 
 
-def test_settings_in_permission_rule():
+def test_settings_in_permission_rule() -> None:
     class App(morepath.App):
         pass
 
     @App.path(path="{id}")
     class Model:
-        def __init__(self, id):
+        def __init__(self, id: str) -> None:
             self.id = id
 
     class Permission:
         pass
 
     @App.verify_identity()
-    def verify_identity(identity):
+    def verify_identity(identity: object) -> bool:
         return True
 
     @App.setting_section(section="permissions")
-    def get_roles_setting():
+    def get_roles_setting() -> dict[str, set[str]]:
         return {
             "read": {"foo"},
         }
 
     @App.permission_rule(model=Model, permission=Permission)
-    def get_permission(app, identity, model, permission):
+    def get_permission(
+        app: App, identity: object, model: Model, permission: object
+    ) -> bool:
         return model.id in app.settings.permissions.read
 
     @App.view(model=Model, permission=Permission)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "Model: %s" % self.id
 
     @App.identity_policy()
     class IdentityPolicy:
-        def identify(self, request):
+        def identify(self, request: object) -> Identity:
             return Identity("testidentity")
 
-        def remember(self, response, request, identity):
+        def remember(
+            self, response: object, request: object, identity: object
+        ) -> object:
             pass
 
-        def forget(self, response, request):
+        def forget(self, response: object, request: object) -> object:
             pass
 
     c = Client(App())

--- a/morepath/tests/test_setting_directive.py
+++ b/morepath/tests/test_setting_directive.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from webtest import TestApp as Client
 
@@ -6,12 +8,12 @@ import morepath
 from morepath.error import ConflictError
 
 
-def test_settings_property():
+def test_settings_property() -> None:
     class App(morepath.App):
         pass
 
     @App.setting("foo", "bar")
-    def get_foo_setting():
+    def get_foo_setting() -> str:
         return "bar"
 
     dectate.commit(App)
@@ -20,7 +22,7 @@ def test_settings_property():
     assert app.settings is app.config.setting_registry
 
 
-def test_app_extends_settings():
+def test_app_extends_settings() -> None:
     class alpha(morepath.App):
         pass
 
@@ -28,11 +30,11 @@ def test_app_extends_settings():
         pass
 
     @alpha.setting("one", "foo")
-    def get_foo_setting():
+    def get_foo_setting() -> str:
         return "FOO"
 
     @beta.setting("one", "bar")
-    def get_bar_setting():
+    def get_bar_setting() -> str:
         return "BAR"
 
     dectate.commit(alpha, beta)
@@ -52,7 +54,7 @@ def test_app_extends_settings():
     assert settings.one.bar == "BAR"
 
 
-def test_app_overrides_settings():
+def test_app_overrides_settings() -> None:
     class alpha(morepath.App):
         pass
 
@@ -60,11 +62,11 @@ def test_app_overrides_settings():
         pass
 
     @alpha.setting("one", "foo")
-    def get_foo_setting():
+    def get_foo_setting() -> str:
         return "FOO"
 
     @beta.setting("one", "foo")
-    def get_bar_setting():
+    def get_bar_setting() -> str:
         return "OVERRIDE"
 
     dectate.commit(alpha, beta)
@@ -73,7 +75,7 @@ def test_app_overrides_settings():
     assert beta().config.setting_registry.one.foo == "OVERRIDE"
 
 
-def test_app_overrides_settings_three():
+def test_app_overrides_settings_three() -> None:
     class alpha(morepath.App):
         pass
 
@@ -84,11 +86,11 @@ def test_app_overrides_settings_three():
         pass
 
     @alpha.setting("one", "foo")
-    def get_foo_setting():
+    def get_foo_setting() -> str:
         return "FOO"
 
     @beta.setting("one", "foo")
-    def get_bar_setting():
+    def get_bar_setting() -> str:
         return "OVERRIDE"
 
     dectate.commit(alpha, beta, gamma)
@@ -96,12 +98,12 @@ def test_app_overrides_settings_three():
     assert gamma().config.setting_registry.one.foo == "OVERRIDE"
 
 
-def test_app_section_settings():
+def test_app_section_settings() -> None:
     class app(morepath.App):
         pass
 
     @app.setting_section("one")
-    def settings():
+    def settings() -> dict[str, str]:
         return {"foo": "FOO", "bar": "BAR"}
 
     dectate.commit(app)
@@ -114,38 +116,38 @@ def test_app_section_settings():
     assert s.one.bar == "BAR"
 
 
-def test_app_section_settings_conflict():
+def test_app_section_settings_conflict() -> None:
     class app(morepath.App):
         pass
 
     @app.setting_section("one")
-    def settings():
+    def settings() -> dict[str, str]:
         return {"foo": "FOO", "bar": "BAR"}
 
     @app.setting("one", "foo")
-    def get_foo():
+    def get_foo() -> str:
         return "another"
 
     with pytest.raises(ConflictError):
         dectate.commit(app)
 
 
-def test_settings_property_in_view():
+def test_settings_property_in_view() -> None:
     class app(morepath.App):
         pass
 
     @app.setting("section", "name")
-    def setting():
+    def setting() -> str:
         return "LAH"
 
     @app.path(path="")
     class Model:
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
     @app.view(model=Model)
-    def default(self, request):
-        return request.app.settings.section.name
+    def default(self: Model, request: morepath.Request) -> str:
+        return request.app.settings.section.name  # type: ignore[no-any-return]
 
     c = Client(app())
 

--- a/morepath/tests/test_template.py
+++ b/morepath/tests/test_template.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from webtest import TestApp as Client
 
@@ -14,14 +16,14 @@ from .fixtures import (
 )
 
 
-def test_template_fixture():
+def test_template_fixture() -> None:
     c = Client(template.App())
 
     response = c.get("/world")
     assert response.body == b"<p>Hello world!</p>\n"
 
 
-def test_template_override_fixture():
+def test_template_override_fixture() -> None:
     c = Client(template_override.App())
 
     response = c.get("/world")
@@ -33,12 +35,12 @@ def test_template_override_fixture():
     assert response.body == b"<div>Hi world!</div>"
 
 
-def test_template_override_not_directed():
+def test_template_override_not_directed() -> None:
     with pytest.raises(ConfigError):
         template_override_under.SubApp.commit()
 
 
-def test_template_override_implicit_fixture():
+def test_template_override_implicit_fixture() -> None:
     c = Client(template_override_implicit.App())
 
     response = c.get("/world")
@@ -50,17 +52,17 @@ def test_template_override_implicit_fixture():
     assert response.body == b"<div>Hi world!</div>"
 
 
-def test_unknown_extension_no_loader():
+def test_unknown_extension_no_loader() -> None:
     with pytest.raises(ConfigError):
         template_unknown_extension.App.commit()
 
 
-def test_unknown_extension_no_render():
+def test_unknown_extension_no_render() -> None:
     with pytest.raises(ConfigError):
         template_unknown_extension_no_render.App.commit()
 
 
-def test_no_template_directories():
+def test_no_template_directories() -> None:
     # we accept no template directories, as it is possible
     # for a base frameworky app not to define any (ChameleonApp, Jinja2App)
     assert template_no_template_directories.App.commit() == {

--- a/morepath/tests/test_toposort.py
+++ b/morepath/tests/test_toposort.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 from morepath.toposort import Info, toposorted
 
 
-def test_toposorted_single_before_after():
+def test_toposorted_single_before_after() -> None:
     a = Info(1, None, None)
     b = Info(2, 1, None)
     c = Info(3, None, 1)
@@ -18,7 +20,7 @@ def test_toposorted_single_before_after():
     assert toposorted(infos) == [c, a, b]
 
 
-def test_toposorted_multi_before_after():
+def test_toposorted_multi_before_after() -> None:
     a = Info(1, None, None)
     b = Info(2, [1], None)
     c = Info(3, None, [1, 2])

--- a/morepath/tests/test_traject.py
+++ b/morepath/tests/test_traject.py
@@ -1,14 +1,16 @@
+from __future__ import annotations
+
 import pytest
 from webob.exc import HTTPBadRequest
 
 import morepath
 from morepath.converter import IDENTITY_CONVERTER, Converter
+from morepath.error import TrajectError
 from morepath.traject import (
     Node,
     ParameterFactory,
     Path,
     Step,
-    TrajectError,
     TrajectRegistry,
     create_path,
     is_identifier,
@@ -18,7 +20,7 @@ from morepath.traject import (
 )
 
 
-def traject_consume():
+def traject_consume() -> None:
     pass
 
 
@@ -27,14 +29,18 @@ class Root:
 
 
 class Model:
-    pass
+    foo: str
+    id: str
+    first_id: str
 
 
 class Special:
-    pass
+    id: str
+    first_id: str
+    second_id: str
 
 
-def test_name_step():
+def test_name_step() -> None:
     step = Step("foo")
     assert step.s == "foo"
     assert step.generalized == "foo"
@@ -44,14 +50,14 @@ def test_name_step():
     assert step.discriminator_info() == "foo"
 
     assert not step.has_variables()
-    variables = {}
+    variables: dict[str, object] = {}
     assert step.match("foo", variables)
     assert variables == {}
     assert not step.match("bar", variables)
     assert variables == {}
 
 
-def test_variable_step():
+def test_variable_step() -> None:
     step = Step("{foo}")
     assert step.s == "{foo}"
     assert step.generalized == "{}"
@@ -61,12 +67,12 @@ def test_variable_step():
     assert step.has_variables()
     assert step.discriminator_info() == "{}"
 
-    variables = {}
+    variables: dict[str, object] = {}
     assert step.match("bar", variables)
     assert variables == {"foo": "bar"}
 
 
-def test_mixed_step():
+def test_mixed_step() -> None:
     step = Step("a{foo}b")
     assert step.s == "a{foo}b"
     assert step.generalized == "a{}b"
@@ -76,7 +82,7 @@ def test_mixed_step():
     assert step.has_variables()
     assert step.discriminator_info() == "a{}b"
 
-    variables = {}
+    variables: dict[str, object] = {}
     assert step.match("abarb", variables)
     assert variables == {"foo": "bar"}
 
@@ -97,7 +103,7 @@ def test_mixed_step():
     assert not variables
 
 
-def test_multi_mixed_step():
+def test_multi_mixed_step() -> None:
     step = Step("{foo}a{bar}")
     assert step.s == "{foo}a{bar}"
     assert step.generalized == "{}a{}"
@@ -108,11 +114,11 @@ def test_multi_mixed_step():
     assert step.discriminator_info() == "{}a{}"
 
 
-def test_converter():
+def test_converter() -> None:
     step = Step("{foo}", converters=dict(foo=Converter(int)))
     assert step.discriminator_info() == "{}"
 
-    variables = {}
+    variables: dict[str, object] = {}
     assert step.match("1", variables)
     assert variables == {"foo": 1}
 
@@ -121,12 +127,12 @@ def test_converter():
     assert not variables
 
 
-def sorted_steps(input_list):
+def sorted_steps(input_list: list[str]) -> list[str]:
     steps = [Step(s) for s in input_list]
     return [step.s for step in sorted(steps)]
 
 
-def test_steps_the_same():
+def test_steps_the_same() -> None:
     step1 = Step("{foo}")
     step2 = Step("{foo}")
     assert step1 == step2
@@ -137,7 +143,7 @@ def test_steps_the_same():
     assert step1 <= step2
 
 
-def test_step_different():
+def test_step_different() -> None:
     step1 = Step("{foo}")
     step2 = Step("bar")
     assert step1 != step2
@@ -148,15 +154,15 @@ def test_step_different():
     assert not step1 <= step2
 
 
-def test_order_prefix_earlier():
+def test_order_prefix_earlier() -> None:
     assert sorted_steps(["{foo}", "prefix{foo}"]) == ["prefix{foo}", "{foo}"]
 
 
-def test_order_postfix_earlier():
+def test_order_postfix_earlier() -> None:
     assert sorted_steps(["{foo}", "{foo}postfix"]) == ["{foo}postfix", "{foo}"]
 
 
-def test_order_prefix_before_postfix():
+def test_order_prefix_before_postfix() -> None:
     assert sorted_steps(["{foo}", "a{foo}", "{foo}a"]) == [
         "a{foo}",
         "{foo}a",
@@ -164,7 +170,7 @@ def test_order_prefix_before_postfix():
     ]
 
 
-def test_order_prefix_before_postfix2():
+def test_order_prefix_before_postfix2() -> None:
     assert sorted_steps(["{foo}", "a{foo}", "{foo}b"]) == [
         "a{foo}",
         "{foo}b",
@@ -172,71 +178,71 @@ def test_order_prefix_before_postfix2():
     ]
 
 
-def test_order_longer_prefix_before_shorter():
+def test_order_longer_prefix_before_shorter() -> None:
     assert sorted_steps(["ab{f}", "a{f}"]) == ["ab{f}", "a{f}"]
 
 
-def test_order_longer_postfix_before_shorter():
+def test_order_longer_postfix_before_shorter() -> None:
     assert sorted_steps(["{f}ab", "{f}b"]) == ["{f}ab", "{f}b"]
 
 
-def test_order_dont_care_variable_names():
+def test_order_dont_care_variable_names() -> None:
     assert sorted_steps(["a{f}", "ab{g}"]) == ["ab{g}", "a{f}"]
 
 
-def test_order_two_variables_before_one():
+def test_order_two_variables_before_one() -> None:
     assert sorted_steps(["{a}x{b}", "{a}"]) == ["{a}x{b}", "{a}"]
 
 
-def test_order_two_variables_before_with_postfix():
+def test_order_two_variables_before_with_postfix() -> None:
     assert sorted_steps(["{a}x{b}x", "{a}x"]) == ["{a}x{b}x", "{a}x"]
 
 
-def test_order_two_variables_before_with_prefix():
+def test_order_two_variables_before_with_prefix() -> None:
     assert sorted_steps(["x{a}x{b}", "x{a}"]) == ["x{a}x{b}", "x{a}"]
 
 
-def test_order_two_variables_infix():
+def test_order_two_variables_infix() -> None:
     assert sorted_steps(
         ["{a}xyz{b}", "{a}xy{b}", "{a}yz{b}", "{a}x{b}", "{a}z{b}", "{a}y{b}"]
     ) == ["{a}xyz{b}", "{a}yz{b}", "{a}z{b}", "{a}xy{b}", "{a}y{b}", "{a}x{b}"]
 
 
-def test_order_alphabetical():
+def test_order_alphabetical() -> None:
     # reverse alphabetical
     assert sorted_steps(["a{f}", "b{f}"]) == ["b{f}", "a{f}"]
     assert sorted_steps(["{f}a", "{f}b"]) == ["{f}b", "{f}a"]
 
 
-def test_invalid_step():
+def test_invalid_step() -> None:
     with pytest.raises(TrajectError):
         Step("{foo")
 
 
-def test_illegal_consecutive_variables():
+def test_illegal_consecutive_variables() -> None:
     with pytest.raises(TrajectError):
         Step("{a}{b}")
 
 
-def test_illegal_variable():
+def test_illegal_variable() -> None:
     with pytest.raises(TrajectError):
         Step("{a:int:int}")
 
 
-def test_illegal_identifier():
+def test_illegal_identifier() -> None:
     with pytest.raises(TrajectError):
         Step("{1}")
 
 
-def test_unknown_converter():
+def test_unknown_converter() -> None:
     with pytest.raises(TrajectError):
         Step("{foo:blurb}")
 
 
-def test_name_node():
+def test_name_node() -> None:
     node = Node()
     step_node = node.add(Step("foo"))
-    variables = {}
+    variables: dict[str, object] = {}
     assert node.resolve("foo", variables) is step_node
     assert not variables
 
@@ -244,11 +250,11 @@ def test_name_node():
     assert not variables
 
 
-def test_variable_node():
+def test_variable_node() -> None:
     node = Node()
 
     step_node = node.add(Step("{x}"))
-    variables = {}
+    variables: dict[str, object] = {}
     assert node.resolve("foo", variables) is step_node
     assert variables == {"x": "foo"}
 
@@ -257,11 +263,11 @@ def test_variable_node():
     assert variables == {"x": "bar"}
 
 
-def test_mixed_node():
+def test_mixed_node() -> None:
     node = Node()
     step_node = node.add(Step("prefix{x}postfix"))
 
-    variables = {}
+    variables: dict[str, object] = {}
     assert node.resolve("prefixfoopostfix", variables) is step_node
     assert variables == {"x": "foo"}
 
@@ -274,13 +280,13 @@ def test_mixed_node():
     assert variables == {}
 
 
-def test_variable_node_specific_first():
+def test_variable_node_specific_first() -> None:
     node = Node()
     x_node = node.add(Step("{x}"))
 
     prefix_node = node.add(Step("prefix{x}"))
 
-    variables = {}
+    variables: dict[str, object] = {}
     assert node.resolve("what", variables) is x_node
     assert variables == {"x": "what"}
 
@@ -289,13 +295,13 @@ def test_variable_node_specific_first():
     assert variables == {"x": "what"}
 
 
-def test_variable_node_more_specific_first():
+def test_variable_node_more_specific_first() -> None:
     node = Node()
     xy_node = node.add(Step("x{x}y"))
     xay_node = node.add(Step("xa{x}y"))
     ay_node = node.add(Step("a{x}y"))
 
-    variables = {}
+    variables: dict[str, object] = {}
     assert node.resolve("xwhaty", variables) is xy_node
     assert variables == {"x": "what"}
 
@@ -308,12 +314,12 @@ def test_variable_node_more_specific_first():
     assert variables == {"x": "what"}
 
 
-def test_variable_node_optional_colon():
+def test_variable_node_optional_colon() -> None:
     node = Node()
     x_node = node.add(Step("{x}"))
     xy_node = node.add(Step("{x}:{y}"))
 
-    variables = {}
+    variables: dict[str, object] = {}
     assert node.resolve("a", variables) is x_node
     assert variables == {"x": "a"}
 
@@ -322,11 +328,11 @@ def test_variable_node_optional_colon():
     assert variables == {"x": "a", "y": "b"}
 
 
-def req(path):
+def req(path: str) -> morepath.Request:
     return morepath.Request.blank(path, app=morepath.App())
 
 
-def test_traject_simple():
+def test_traject_simple() -> None:
     traject = TrajectRegistry()
 
     class abc:
@@ -375,15 +381,15 @@ def test_traject_simple():
     assert r.unconsumed == []
 
 
-def test_traject_variable_specific_first():
+def test_traject_variable_specific_first() -> None:
     traject = TrajectRegistry()
 
     class axb:
-        def __init__(self, x):
+        def __init__(self, x: str) -> None:
             self.x = x
 
     class aprefixxb:
-        def __init__(self, x):
+        def __init__(self, x: str) -> None:
             self.x = x
 
     traject.add_pattern("a/{x}/b", axb)
@@ -398,11 +404,11 @@ def test_traject_variable_specific_first():
     assert obj.x == "lah"
 
 
-def test_traject_multiple_steps_with_variables():
+def test_traject_multiple_steps_with_variables() -> None:
     traject = TrajectRegistry()
 
     class xy:
-        def __init__(self, x, y):
+        def __init__(self, x: str, y: str) -> None:
             self.x = x
             self.y = y
 
@@ -412,11 +418,11 @@ def test_traject_multiple_steps_with_variables():
     assert obj.y == "y"
 
 
-def test_traject_with_converter():
+def test_traject_with_converter() -> None:
     traject = TrajectRegistry()
 
     class found:
-        def __init__(self, x):
+        def __init__(self, x: int) -> None:
             self.x = x
 
     traject.add_pattern("{x}", found, converters=dict(x=Converter(int)))
@@ -427,15 +433,15 @@ def test_traject_with_converter():
     assert traject.consume(req("foo")) is None
 
 
-def test_traject_type_conflict():
+def test_traject_type_conflict() -> None:
     traject = TrajectRegistry()
 
     class found_int:
-        def __init__(self, x):
+        def __init__(self, x: int) -> None:
             self.x = x
 
     class found_str:
-        def __init__(self, x):
+        def __init__(self, x: str) -> None:
             self.x = x
 
     traject.add_pattern("{x}", found_int, converters=dict(x=Converter(int)))
@@ -443,15 +449,15 @@ def test_traject_type_conflict():
         traject.add_pattern("{x}", found_str, converters=dict(x=Converter(str)))
 
 
-def test_traject_type_conflict_default_type():
+def test_traject_type_conflict_default_type() -> None:
     traject = TrajectRegistry()
 
     class found_str:
-        def __init__(self, x):
+        def __init__(self, x: str) -> None:
             self.x = x
 
     class found_int:
-        def __init__(self, x):
+        def __init__(self, x: int) -> None:
             self.x = x
 
     traject.add_pattern("{x}", found_str)
@@ -459,15 +465,15 @@ def test_traject_type_conflict_default_type():
         traject.add_pattern("{x}", found_int, converters=dict(x=Converter(int)))
 
 
-def test_traject_type_conflict_explicit_default():
+def test_traject_type_conflict_explicit_default() -> None:
     traject = TrajectRegistry()
 
     class found_explicit:
-        def __init__(self, x):
+        def __init__(self, x: str) -> None:
             self.x = x
 
     class found_implicit:
-        def __init__(self, x):
+        def __init__(self, x: str) -> None:
             self.x = x
 
     traject.add_pattern(
@@ -478,15 +484,15 @@ def test_traject_type_conflict_explicit_default():
     assert True
 
 
-def test_traject_type_conflict_middle():
+def test_traject_type_conflict_middle() -> None:
     traject = TrajectRegistry()
 
     class int_f:
-        def __init__(self, x):
+        def __init__(self, x: int) -> None:
             self.x = x
 
     class str_f:
-        def __init__(self, x):
+        def __init__(self, x: str) -> None:
             self.x = x
 
     traject.add_pattern("a/{x}/y", int_f, converters=dict(x=Converter(int)))
@@ -494,30 +500,30 @@ def test_traject_type_conflict_middle():
         traject.add_pattern("a/{x}/z", str_f)
 
 
-def test_traject_no_type_conflict_middle():
+def test_traject_no_type_conflict_middle() -> None:
     traject = TrajectRegistry()
 
     class int_f:
-        def __init__(self, x):
+        def __init__(self, x: int) -> None:
             self.x = x
 
     class int_f2:
-        def __init__(self, x):
+        def __init__(self, x: int) -> None:
             self.x = x
 
     traject.add_pattern("a/{x}/y", int_f, converters=dict(x=Converter(int)))
     traject.add_pattern("a/{x}/z", int_f2, converters=dict(x=Converter(int)))
 
 
-def test_traject_greedy_middle_prefix():
+def test_traject_greedy_middle_prefix() -> None:
     traject = TrajectRegistry()
 
     class prefix:
-        def __init__(self, x):
+        def __init__(self, x: str) -> None:
             self.x = x
 
     class no_prefix:
-        def __init__(self, x):
+        def __init__(self, x: str) -> None:
             self.x = x
 
     traject.add_pattern("a/prefix{x}/y", prefix)
@@ -534,15 +540,15 @@ def test_traject_greedy_middle_prefix():
     assert isinstance(obj, no_prefix)
 
 
-def test_traject_type_conflict_middle_end():
+def test_traject_type_conflict_middle_end() -> None:
     traject = TrajectRegistry()
 
     class int_f:
-        def __init__(self, x):
+        def __init__(self, x: int) -> None:
             self.x = x
 
     class str_f:
-        def __init__(self, x):
+        def __init__(self, x: str) -> None:
             self.x = x
 
     traject.add_pattern("a/{x}/y", int_f, converters=dict(x=Converter(int)))
@@ -550,15 +556,15 @@ def test_traject_type_conflict_middle_end():
         traject.add_pattern("a/{x}", str_f)
 
 
-def test_traject_no_type_conflict_middle_end():
+def test_traject_no_type_conflict_middle_end() -> None:
     traject = TrajectRegistry()
 
     class int_f:
-        def __init__(self, x):
+        def __init__(self, x: int) -> None:
             self.x = x
 
     class int_f2:
-        def __init__(self, x):
+        def __init__(self, x: int) -> None:
             self.x = x
 
     traject.add_pattern("a/{x}/y", int_f, converters=dict(x=Converter(int)))
@@ -566,50 +572,50 @@ def test_traject_no_type_conflict_middle_end():
     assert True
 
 
-def test_parse_path():
+def test_parse_path() -> None:
     assert parse_path("/a/b/c") == ["a", "b", "c"]
 
 
-def test_parse_path_empty():
+def test_parse_path_empty() -> None:
     assert parse_path("") == []
 
 
-def test_parse_path_slash():
+def test_parse_path_slash() -> None:
     assert parse_path("/") == []
 
 
-def test_parse_path_no_slash():
+def test_parse_path_no_slash() -> None:
     assert parse_path("a/b/c") == ["a", "b", "c"]
 
 
-def test_parse_path_end_slash():
+def test_parse_path_end_slash() -> None:
     assert parse_path("a/b/c/") == ["a", "b", "c"]
 
 
-def test_parse_path_multi_slash():
+def test_parse_path_multi_slash() -> None:
     assert parse_path("/a/b/c") == parse_path("/a//b/c")
     assert parse_path("/a/b/c") == parse_path("/a///b/c")
 
 
-def test_parse_path_dots():
+def test_parse_path_dots() -> None:
     assert parse_path("/a/b/../c") == parse_path("/a/c")
 
 
-def test_parse_path_single_dots():
+def test_parse_path_single_dots() -> None:
     assert parse_path("/a/./b") == parse_path("/a/b")
     assert parse_path("./a/b") == parse_path("/a/b")
 
 
-def test_parse_path_dots_start():
+def test_parse_path_dots_start() -> None:
     assert parse_path("/../a/b") == parse_path("/a/b")
 
 
-def test_create_path():
+def test_create_path() -> None:
     assert create_path(["a", "b", "c"]) == "/a/b/c"
     assert create_path([]) == "/"
 
 
-def test_normalize_path():
+def test_normalize_path() -> None:
     assert normalize_path("/a/..") == "/"
     assert normalize_path("/a/../../../../b") == "/b"
     assert normalize_path("/a/../c") == "/c"
@@ -625,9 +631,9 @@ def test_normalize_path():
     assert normalize_path("/a/b/c/../../d") == "/a/d"
 
 
-def test_identifier():
+def test_identifier() -> None:
     assert is_identifier("a")
-    not is_identifier("")
+    assert not is_identifier("")
     assert is_identifier("a1")
     assert not is_identifier("1")
     assert is_identifier("_")
@@ -636,7 +642,7 @@ def test_identifier():
     assert not is_identifier(".")
 
 
-def test_parse_variables():
+def test_parse_variables() -> None:
     assert parse_variables("No variables") == []
     assert parse_variables("The {foo} is the {bar}.") == ["foo", "bar"]
     with pytest.raises(TrajectError):
@@ -645,7 +651,7 @@ def test_parse_variables():
         parse_variables("{1illegal}")
 
 
-def test_traject_consume():
+def test_traject_consume() -> None:
     class App(morepath.App):
         pass
 
@@ -661,7 +667,7 @@ def test_traject_consume():
     assert r.unconsumed == []
 
 
-def test_traject_consume_parameter():
+def test_traject_consume_parameter() -> None:
     class App(morepath.App):
         pass
 
@@ -670,7 +676,7 @@ def test_traject_consume_parameter():
     traject = App.config.path_registry
 
     class Model:
-        def __init__(self, a):
+        def __init__(self, a: int) -> None:
             self.a = a
 
     traject.add_pattern(
@@ -694,7 +700,7 @@ def test_traject_consume_parameter():
     assert r.unconsumed == []
 
 
-def test_traject_consume_model_factory_gets_request():
+def test_traject_consume_model_factory_gets_request() -> None:
     class App(morepath.App):
         pass
 
@@ -702,12 +708,12 @@ def test_traject_consume_model_factory_gets_request():
 
     traject = App.config.path_registry
 
-    class Model:
-        def __init__(self, info):
+    class MyModel:
+        def __init__(self, info: str) -> None:
             self.info = info
 
-    def get_model(request):
-        return Model(request.method)
+    def get_model(request: morepath.Request) -> MyModel:
+        return MyModel(request.method)
 
     traject.add_pattern("sub", get_model)
 
@@ -717,7 +723,7 @@ def test_traject_consume_model_factory_gets_request():
     assert obj.info == "GET"
 
 
-def test_traject_consume_not_found():
+def test_traject_consume_not_found() -> None:
     class App(morepath.App):
         pass
 
@@ -730,7 +736,7 @@ def test_traject_consume_not_found():
     assert r.unconsumed == ["sub"]
 
 
-def test_traject_consume_factory_returns_none():
+def test_traject_consume_factory_returns_none() -> None:
     class App(morepath.App):
         pass
 
@@ -738,7 +744,7 @@ def test_traject_consume_factory_returns_none():
 
     traject = App.config.path_registry
 
-    def get_model():
+    def get_model() -> None:
         return None
 
     traject.add_pattern("sub", get_model)
@@ -748,7 +754,7 @@ def test_traject_consume_factory_returns_none():
     assert r.unconsumed == []
 
 
-def test_traject_consume_variable():
+def test_traject_consume_variable() -> None:
     class App(morepath.App):
         pass
 
@@ -756,7 +762,7 @@ def test_traject_consume_variable():
 
     traject = App.config.path_registry
 
-    def get_model(foo):
+    def get_model(foo: str) -> Model:
         result = Model()
         result.foo = foo
         return result
@@ -771,7 +777,7 @@ def test_traject_consume_variable():
     assert r.unconsumed == []
 
 
-def test_traject_consume_view():
+def test_traject_consume_view() -> None:
     class App(morepath.App):
         pass
 
@@ -779,7 +785,7 @@ def test_traject_consume_view():
 
     traject = App.config.path_registry
 
-    def get_model(foo):
+    def get_model(foo: str) -> Model:
         result = Model()
         result.foo = foo
         return result
@@ -794,7 +800,7 @@ def test_traject_consume_view():
     assert r.unconsumed == ["+something"]
 
 
-def test_traject_root():
+def test_traject_root() -> None:
     class App(morepath.App):
         pass
 
@@ -810,7 +816,7 @@ def test_traject_root():
     assert r.unconsumed == []
 
 
-def test_traject_consume_combination():
+def test_traject_consume_combination() -> None:
     class App(morepath.App):
         pass
 
@@ -818,7 +824,7 @@ def test_traject_consume_combination():
 
     traject = App.config.path_registry
 
-    def get_model(foo):
+    def get_model(foo: str) -> Model:
         result = Model()
         result.foo = foo
         return result
@@ -838,7 +844,7 @@ def test_traject_consume_combination():
     assert r.unconsumed == []
 
 
-def test_traject_consume_extra_path_variable():
+def test_traject_consume_extra_path_variable() -> None:
     class App(morepath.App):
         pass
 
@@ -846,7 +852,7 @@ def test_traject_consume_extra_path_variable():
 
     traject = App.config.path_registry
 
-    def get_model(foo):
+    def get_model(foo: str) -> Model:
         result = Model()
         result.foo = foo
         return result
@@ -860,7 +866,7 @@ def test_traject_consume_extra_path_variable():
         traject.consume(r)
 
 
-def test_traject_nested():
+def test_traject_nested() -> None:
     class App(morepath.App):
         pass
 
@@ -881,7 +887,7 @@ def test_traject_nested():
     assert r.unconsumed == []
 
 
-def test_traject_nested_not_resolved_entirely_by_consumer():
+def test_traject_nested_not_resolved_entirely_by_consumer() -> None:
     class App(morepath.App):
         pass
 
@@ -901,7 +907,7 @@ def test_traject_nested_not_resolved_entirely_by_consumer():
     assert r.unconsumed == ["b"]
 
 
-def test_traject_nested_with_variable():
+def test_traject_nested_with_variable() -> None:
     class App(morepath.App):
         pass
 
@@ -909,12 +915,12 @@ def test_traject_nested_with_variable():
 
     traject = App.config.path_registry
 
-    def get_model(id):
+    def get_model(id: str) -> Model:
         result = Model()
         result.id = id
         return result
 
-    def get_special(id):
+    def get_special(id: str) -> Special:
         result = Special()
         result.id = id
         return result
@@ -938,7 +944,7 @@ def test_traject_nested_with_variable():
     assert r.unconsumed == []
 
 
-def test_traject_with_multiple_variables():
+def test_traject_with_multiple_variables() -> None:
     class App(morepath.App):
         pass
 
@@ -946,12 +952,12 @@ def test_traject_with_multiple_variables():
 
     traject = App.config.path_registry
 
-    def get_model(first_id):
+    def get_model(first_id: str) -> Model:
         result = Model()
         result.first_id = first_id
         return result
 
-    def get_special(first_id, second_id):
+    def get_special(first_id: str, second_id: str) -> Special:
         result = Special()
         result.first_id = first_id
         result.second_id = second_id
@@ -975,20 +981,20 @@ def test_traject_with_multiple_variables():
     assert r.unconsumed == []
 
 
-def test_traject_no_concecutive_variables():
+def test_traject_no_concecutive_variables() -> None:
     traject = TrajectRegistry()
 
-    def f():
+    def f() -> None:
         pass
 
     with pytest.raises(TrajectError):
         traject.add_pattern("{foo}{bar}", f)
 
 
-def test_traject_no_duplicate_variables():
+def test_traject_no_duplicate_variables() -> None:
     traject = TrajectRegistry()
 
-    def f():
+    def f() -> None:
         pass
 
     with pytest.raises(TrajectError):
@@ -997,29 +1003,29 @@ def test_traject_no_duplicate_variables():
         traject.add_pattern("{foo}/{foo}", f)
 
 
-def test_interpolation_str():
+def test_interpolation_str() -> None:
     assert Path("{foo} is {bar}").interpolation_str() == "%(foo)s is %(bar)s"
 
 
-def test_path_discriminator():
+def test_path_discriminator() -> None:
     p = Path("/foo/{x}/bar/{y}")
     assert p.discriminator() == "foo/{}/bar/{}"
 
 
-def test_empty_parameter_factory():
+def test_empty_parameter_factory() -> None:
     get_parameters = ParameterFactory({}, {}, [])
     assert get_parameters(req("")) == {}
     # unexpected parameter is ignored
     assert get_parameters(req("?a=A")) == {}
 
 
-def test_single_parameter():
+def test_single_parameter() -> None:
     get_parameters = ParameterFactory({"a": None}, {"a": Converter(str)}, [])
     assert get_parameters(req("?a=A")) == {"a": "A"}
     assert get_parameters(req("")) == {"a": None}
 
 
-def test_single_parameter_int():
+def test_single_parameter_int() -> None:
     get_parameters = ParameterFactory({"a": None}, {"a": Converter(int)}, [])
     assert get_parameters(req("?a=1")) == {"a": 1}
     assert get_parameters(req("")) == {"a": None}
@@ -1027,13 +1033,13 @@ def test_single_parameter_int():
         get_parameters(req("?a=A"))
 
 
-def test_single_parameter_default():
+def test_single_parameter_default() -> None:
     get_parameters = ParameterFactory({"a": "default"}, {}, [])
     assert get_parameters(req("?a=A")) == {"a": "A"}
     assert get_parameters(req("")) == {"a": "default"}
 
 
-def test_single_parameter_int_default():
+def test_single_parameter_int_default() -> None:
     get_parameters = ParameterFactory({"a": 0}, {"a": Converter(int)}, [])
     assert get_parameters(req("?a=1")) == {"a": 1}
     assert get_parameters(req("")) == {"a": 0}
@@ -1041,14 +1047,14 @@ def test_single_parameter_int_default():
         get_parameters(req("?a=A"))
 
 
-def test_parameter_required():
+def test_parameter_required() -> None:
     get_parameters = ParameterFactory({"a": None}, {}, ["a"])
     assert get_parameters(req("?a=foo")) == {"a": "foo"}
     with pytest.raises(HTTPBadRequest):
         get_parameters(req(""))
 
 
-def test_extra_parameters():
+def test_extra_parameters() -> None:
     get_parameters = ParameterFactory({"a": None}, {}, [], True)
     assert get_parameters(req("?a=foo")) == {"a": "foo", "extra_parameters": {}}
     assert get_parameters(req("?b=foo")) == {

--- a/morepath/tests/test_tween.py
+++ b/morepath/tests/test_tween.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
 from webtest import TestApp as Client
 
@@ -5,89 +9,94 @@ import morepath
 from morepath.error import TopologicalSortError
 from morepath.tween import TweenRegistry
 
+if TYPE_CHECKING:
+    from webob import Response as BaseResponse
 
-def test_tween_sorting_no_tweens():
+    from morepath.types import Tween
+
+
+def test_tween_sorting_no_tweens() -> None:
     reg = TweenRegistry()
     assert reg.sorted_tween_factories() == []
 
 
-def test_tween_sorting_one_tween():
+def test_tween_sorting_one_tween() -> None:
     reg = TweenRegistry()
 
-    def foo():
-        pass
+    def foo(app: morepath.App, handler: Tween) -> Tween:
+        return handler
 
     reg.register_tween_factory(foo, over=None, under=None)
     assert reg.sorted_tween_factories() == [foo]
 
 
-def test_tween_sorting_two_tweens_under():
+def test_tween_sorting_two_tweens_under() -> None:
     reg = TweenRegistry()
 
-    def top():
-        pass
+    def top(app: morepath.App, handler: Tween) -> Tween:
+        return handler
 
-    def bottom():
-        pass
+    def bottom(app: morepath.App, handler: Tween) -> Tween:
+        return handler
 
     reg.register_tween_factory(top, over=None, under=None)
     reg.register_tween_factory(bottom, over=None, under=top)
     assert reg.sorted_tween_factories() == [top, bottom]
 
 
-def test_tween_sorting_two_tweens_under_reverse_reg():
+def test_tween_sorting_two_tweens_under_reverse_reg() -> None:
     reg = TweenRegistry()
 
-    def top():
-        pass
+    def top(app: morepath.App, handler: Tween) -> Tween:
+        return handler
 
-    def bottom():
-        pass
+    def bottom(app: morepath.App, handler: Tween) -> Tween:
+        return handler
 
     reg.register_tween_factory(bottom, over=None, under=top)
     reg.register_tween_factory(top, over=None, under=None)
     assert reg.sorted_tween_factories() == [top, bottom]
 
 
-def test_tween_sorting_two_tweens_over():
+def test_tween_sorting_two_tweens_over() -> None:
     reg = TweenRegistry()
 
-    def top():
-        pass
+    def top(app: morepath.App, handler: Tween) -> Tween:
+        return handler
 
-    def bottom():
-        pass
+    def bottom(app: morepath.App, handler: Tween) -> Tween:
+        return handler
 
     reg.register_tween_factory(top, over=bottom, under=None)
     reg.register_tween_factory(bottom, over=None, under=None)
     assert reg.sorted_tween_factories() == [top, bottom]
 
 
-def test_tween_sorting_two_tweens_over_reverse_reg():
+def test_tween_sorting_two_tweens_over_reverse_reg() -> None:
     reg = TweenRegistry()
 
-    def top():
-        pass
+    def top(app: morepath.App, handler: Tween) -> Tween:
+        return handler
 
-    def bottom():
-        pass
+    def bottom(app: morepath.App, handler: Tween) -> Tween:
+        return handler
 
     reg.register_tween_factory(bottom, over=None, under=None)
     reg.register_tween_factory(top, over=bottom, under=None)
     assert reg.sorted_tween_factories() == [top, bottom]
 
 
-def test_tween_sorting_three():
+def test_tween_sorting_three() -> None:
     reg = TweenRegistry()
 
-    def a():
-        pass
+    def a(app: morepath.App, handler: Tween) -> Tween:
+        return handler
 
-    def b():
-        pass
+    def b(app: morepath.App, handler: Tween) -> Tween:
+        return handler
 
-    def c():
-        pass
+    def c(app: morepath.App, handler: Tween) -> Tween:
+        return handler
 
     reg.register_tween_factory(a, over=None, under=None)
     reg.register_tween_factory(b, over=None, under=a)
@@ -95,11 +104,11 @@ def test_tween_sorting_three():
     assert reg.sorted_tween_factories() == [c, a, b]
 
 
-def test_tween_sorting_dag_error():
+def test_tween_sorting_dag_error() -> None:
     reg = TweenRegistry()
 
-    def a():
-        pass
+    def a(app: morepath.App, handler: Tween) -> Tween:
+        return handler
 
     reg.register_tween_factory(a, over=None, under=a)
 
@@ -107,11 +116,11 @@ def test_tween_sorting_dag_error():
         reg.sorted_tween_factories()
 
 
-def test_tween_sorting_dag_error2():
+def test_tween_sorting_dag_error2() -> None:
     reg = TweenRegistry()
 
-    def a():
-        pass
+    def a(app: morepath.App, handler: Tween) -> Tween:
+        return handler
 
     reg.register_tween_factory(a, over=a, under=None)
 
@@ -119,14 +128,14 @@ def test_tween_sorting_dag_error2():
         reg.sorted_tween_factories()
 
 
-def test_tween_sorting_dag_error3():
+def test_tween_sorting_dag_error3() -> None:
     reg = TweenRegistry()
 
-    def a():
-        pass
+    def a(app: morepath.App, handler: Tween) -> Tween:
+        return handler
 
-    def b():
-        pass
+    def b(app: morepath.App, handler: Tween) -> Tween:
+        return handler
 
     reg.register_tween_factory(a, over=b, under=None)
     reg.register_tween_factory(b, over=a, under=None)
@@ -135,17 +144,17 @@ def test_tween_sorting_dag_error3():
         reg.sorted_tween_factories()
 
 
-def test_tween_sorting_dag_error4():
+def test_tween_sorting_dag_error4() -> None:
     reg = TweenRegistry()
 
-    def a():
-        pass
+    def a(app: morepath.App, handler: Tween) -> Tween:
+        return handler
 
-    def b():
-        pass
+    def b(app: morepath.App, handler: Tween) -> Tween:
+        return handler
 
-    def c():
-        pass
+    def c(app: morepath.App, handler: Tween) -> Tween:
+        return handler
 
     reg.register_tween_factory(a, over=b, under=None)
     reg.register_tween_factory(b, over=c, under=None)
@@ -155,7 +164,7 @@ def test_tween_sorting_dag_error4():
         reg.sorted_tween_factories()
 
 
-def test_tween_directive():
+def test_tween_directive() -> None:
     class app(morepath.App):
         pass
 
@@ -164,12 +173,12 @@ def test_tween_directive():
         pass
 
     @app.view(model=Root)
-    def default(self, request):
+    def default(self: Root, request: morepath.Request) -> str:
         return "View"
 
     @app.tween_factory()
-    def get_modify_response_tween(app, handler):
-        def plusplustween(request):
+    def get_modify_response_tween(app: app, handler: Tween) -> Tween:
+        def plusplustween(request: morepath.Request) -> BaseResponse:
             response = handler(request)
             response.headers["Tween-Header"] = "FOO"
             return response

--- a/morepath/tests/test_view_directive.py
+++ b/morepath/tests/test_view_directive.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from webtest import TestApp as Client
 
@@ -7,17 +9,17 @@ from morepath.core import request_method_predicate
 from reg import ClassIndex, KeyIndex
 
 
-def test_view_get_only():
+def test_view_get_only() -> None:
     class App(morepath.App):
         pass
 
     @App.path(path="")
     class Model:
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View"
 
     c = Client(App())
@@ -28,28 +30,28 @@ def test_view_get_only():
     response = c.post("/", status=405)
 
 
-def test_view_name_conflict_involving_default():
+def test_view_name_conflict_involving_default() -> None:
     class App(morepath.App):
         pass
 
     @App.path(path="")
     class Model:
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View"
 
     @App.view(model=Model, name="")
-    def default2(self, request):
+    def default2(self: Model, request: morepath.Request) -> str:
         return "View"
 
     with pytest.raises(ConflictError):
         App.commit()
 
 
-def test_view_custom_predicate_conflict_involving_default_extends():
+def test_view_custom_predicate_conflict_involving_default_extends() -> None:
     class Core(morepath.App):
         pass
 
@@ -63,27 +65,27 @@ def test_view_custom_predicate_conflict_involving_default_extends():
         index=ClassIndex,
         after=request_method_predicate,
     )
-    def dummy_predicate(request):
+    def dummy_predicate(request: morepath.Request) -> None:
         return None
 
     @App.path(path="")
     class Model:
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
     @App.view(model=Model)
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View"
 
     @App.view(model=Model, extra="DEFAULT")
-    def default2(self, request):
+    def default2(self: Model, request: morepath.Request) -> str:
         return "View"
 
     with pytest.raises(ConflictError):
         App.commit()
 
 
-def test_view_custom_predicate_without_fallback():
+def test_view_custom_predicate_without_fallback() -> None:
     class Core(morepath.App):
         pass
 
@@ -97,20 +99,22 @@ def test_view_custom_predicate_without_fallback():
         index=KeyIndex,
         after=request_method_predicate,
     )
-    def dummy_predicate(self, obj, request):
+    def dummy_predicate(
+        self: Core, obj: object, request: morepath.Request
+    ) -> str:
         return "match"
 
     @App.path(path="")
     class Model:
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
     @App.view(model=Model, extra="match")
-    def default(self, request):
+    def default(self: Model, request: morepath.Request) -> str:
         return "View"
 
     @App.view(model=Model, name="foo", extra="not match")
-    def not_match(self, request):
+    def not_match(self: Model, request: morepath.Request) -> str:
         return "Not match"
 
     c = Client(App())

--- a/morepath/toposort.py
+++ b/morepath/toposort.py
@@ -1,16 +1,27 @@
 """Topological sort functionality."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
+
 from dectate import topological_sort
 
+if TYPE_CHECKING:
+    from collections.abc import Collection
 
-def toposorted(infos):
+
+_T = TypeVar("_T")
+_InfoT = TypeVar("_InfoT", bound="Info[Any]")
+
+
+def toposorted(infos: Collection[_InfoT]) -> list[_InfoT]:
     """Sort infos topologically.
 
     Info object must have a ``key`` attribute, and ``before`` and ``after``
     attributes that returns a list of keys. You can use :class:`Info`.
     """
-    key_to_info = {}
-    depends = {}
+    key_to_info: dict[Any, _InfoT] = {}
+    depends: dict[Any, list[_InfoT]] = {}
     for info in infos:
         key_to_info[info.key] = info
         depends[info.key] = []
@@ -24,20 +35,27 @@ def toposorted(infos):
     return topological_sort(infos, lambda info: depends[info.key])
 
 
-class Info:
+class Info(Generic[_T]):
     """Toposorted info helper.
 
     Base class that helps with toposorted. ``before`` and ``after``
     can be lists of keys, or a single key, or ``None``.
     """
 
-    def __init__(self, key, before, after):
+    def __init__(
+        self,
+        key: _T,
+        before: list[_T] | tuple[_T, ...] | _T | None,
+        after: list[_T] | tuple[_T, ...] | _T | None,
+    ) -> None:
         self.key = key
         self.before = _convert_before_after(before)
         self.after = _convert_before_after(after)
 
 
-def _convert_before_after(keys):
+def _convert_before_after(
+    keys: list[_T] | tuple[_T, ...] | _T | None,
+) -> list[_T]:
     if isinstance(keys, (list, tuple)):
         return list(keys)
     elif keys is None:

--- a/morepath/traject.py
+++ b/morepath/traject.py
@@ -28,8 +28,11 @@ https://littledev.nl/blog/2015-01-13-url-routing
 
 """
 
+from __future__ import annotations
+
 import re
 from functools import total_ordering
+from typing import TYPE_CHECKING, Any
 
 from webob.exc import HTTPBadRequest
 
@@ -37,6 +40,14 @@ from reg import arginfo
 
 from .converter import IDENTITY_CONVERTER
 from .error import TrajectError
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Collection
+
+    from dectate import CodeInfo
+
+    from .request import Request
+    from .types import AnyConverter
 
 IDENTIFIER = re.compile(r"^[^\d\W]\w*$")
 """regex for a valid variable name in a route.
@@ -58,7 +69,9 @@ class Step:
     :param converters: dict of converters for variables.
     """
 
-    def __init__(self, s, converters=None):
+    def __init__(
+        self, s: str, converters: dict[str, AnyConverter] | None = None
+    ) -> None:
         self.s = s
         self.converters = converters or {}
         self.generalized = generalize_variables(s)
@@ -75,7 +88,7 @@ class Step:
             ("%(" + name + ")s") for name in self.names
         )
 
-    def validate(self):
+    def validate(self) -> None:
         """Validate whether step makes sense.
 
         Raises :class:`morepath.error.TrajectError` if there is a problem
@@ -84,7 +97,7 @@ class Step:
         self.validate_parts()
         self.validate_variables()
 
-    def validate_parts(self):
+    def validate_parts(self) -> None:
         """Check whether all non-variable parts of the segment are valid.
 
         Raises :class:`morepath.error.TrajectError` if there is a problem
@@ -95,7 +108,7 @@ class Step:
             if "{" in part or "}" in part:
                 raise TrajectError("invalid step: %s" % self.s)
 
-    def validate_variables(self):
+    def validate_variables(self) -> None:
         """Check whether all variables of the segment are valid.
 
         Raises :class:`morepath.error.TrajectError` if there is a problem
@@ -110,15 +123,15 @@ class Step:
             if part == "":
                 raise TrajectError("illegal consecutive variables: %s" % self.s)
 
-    def discriminator_info(self):
+    def discriminator_info(self) -> str:
         """Information needed to construct path discriminator."""
         return self.generalized
 
-    def has_variables(self):
+    def has_variables(self) -> bool:
         """True if there are any variables in this step."""
         return bool(self.names)
 
-    def match(self, s, variables):
+    def match(self, s: str, variables: dict[str, Any]) -> bool:
         """Match this step with actual path segment.
 
         :param s: path segment to match with
@@ -139,19 +152,23 @@ class Step:
                 return False
         return True
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         """True if this step is the same as another."""
+        if not isinstance(other, self.__class__):
+            return False
         if self.s != other.s:
             return False
         return self.cmp_converters == other.cmp_converters
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         """True if this step is not equal to another."""
+        if not isinstance(other, self.__class__):
+            return True
         if self.s != other.s:
             return True
         return self.cmp_converters != other.cmp_converters
 
-    def __lt__(self, other):
+    def __lt__(self, other: Step) -> bool:
         """Used for inserting steps in correct place in the tree.
 
         The order in which a step is inserted into the tree compared
@@ -181,19 +198,21 @@ class Step:
 class Node:
     """A node in the traject tree."""
 
-    def __init__(self):
-        self._name_nodes = {}
-        self._variable_nodes = []
+    def __init__(self) -> None:
+        self._name_nodes: dict[str, StepNode] = {}
+        self._variable_nodes: list[StepNode] = []
         self.absorb = False
-        self.create = lambda variables, request: None
+        self.create: Callable[[dict[str, Any], Request], Any] = (
+            lambda variables, request: None
+        )
 
-    def add(self, step):
+    def add(self, step: Step) -> StepNode:
         """Add a step into the tree as a child node of this node."""
         if not step.has_variables():
             return self.add_name_node(step)
         return self.add_variable_node(step)
 
-    def add_name_node(self, step):
+    def add_name_node(self, step: Step) -> StepNode:
         """Add a step into the tree as a node that doesn't match variables."""
         node = self._name_nodes.get(step.s)
         if node is not None:
@@ -202,7 +221,7 @@ class Node:
         self._name_nodes[step.s] = node
         return node
 
-    def add_variable_node(self, step):
+    def add_variable_node(self, step: Step) -> StepNode:
         """Add a step into the tree as a node that matches variables."""
         for i, node in enumerate(self._variable_nodes):
             if node.step == step:
@@ -220,7 +239,9 @@ class Node:
         self._variable_nodes.append(result)
         return result
 
-    def resolve(self, segment, variables):
+    def resolve(
+        self, segment: str, variables: dict[str, Any]
+    ) -> StepNode | None:
         """Match a path segment, traversing this node.
 
         Matches non-variable nodes before nodes with variables in them.
@@ -247,11 +268,11 @@ class StepNode(Node):
     :param step: the step
     """
 
-    def __init__(self, step):
+    def __init__(self, step: Step) -> None:
         super().__init__()
         self.step = step
 
-    def match(self, segment, variables):
+    def match(self, segment: str, variables: dict[str, Any]) -> bool:
         """Match a segment with the step."""
         return self.step.match(segment, variables)
 
@@ -267,48 +288,45 @@ class Path:
     :param path: the route.
     """
 
-    def __init__(self, path):
+    def __init__(self, path: str) -> None:
         self.steps = [Step(segment) for segment in parse_path(path)]
 
-    def discriminator(self):
+    def discriminator(self) -> str:
         """Creates a unique discriminator for the path."""
-        return "/".join([step.discriminator_info() for step in self.steps])
+        return "/".join(step.discriminator_info() for step in self.steps)
 
-    def interpolation_str(self):
+    def interpolation_str(self) -> str:
         """Create a string for interpolating variables.
 
         Used for link generation (inverse).
         """
-        return "/".join([step.named_interpolation_str for step in self.steps])
+        return "/".join(step.named_interpolation_str for step in self.steps)
 
-    def variables(self):
+    def variables(self) -> set[str]:
         """Get the variables used by the path.
 
-        :return: a list of variable names
+        :return: a set of variable names
         """
-        result = []
-        for step in self.steps:
-            result.extend(step.names)
-        return set(result)
+        return {name for step in self.steps for name in step.names}
 
 
 class TrajectRegistry:
     """Tree of route steps."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._root = Node()
 
     def add_pattern(
         self,
-        path,
-        model_factory,
-        defaults=None,
-        converters=None,
-        absorb=False,
-        required=None,
-        extra=None,
-        code_info=None,
-    ):
+        path: str,
+        model_factory: Callable[..., Any],
+        defaults: dict[str, Any] | None = None,
+        converters: dict[str, AnyConverter] | None = None,
+        absorb: bool = False,
+        required: Collection[str] | None = None,
+        extra: bool = False,
+        code_info: CodeInfo | None = None,
+    ) -> None:
         """Add a route to the tree.
 
         :param path: route to add.
@@ -324,7 +342,7 @@ class TrajectRegistry:
 
         """
         node = self._root
-        known_variables = set()
+        known_variables: set[str] = set()
         for segment in parse_path(path):
             step = Step(segment, converters)
             node = node.add(step)
@@ -332,18 +350,22 @@ class TrajectRegistry:
             if known_variables.intersection(variables):
                 raise TrajectError("Duplicate variables")
             known_variables.update(variables)
+
+        parameter_factory: Callable[[Request], dict[str, Any]]
         if defaults or converters or required or extra:
             parameter_factory = ParameterFactory(
-                defaults, converters, required, extra
+                defaults, converters or {}, required or (), extra
             )
         else:
             parameter_factory = _simple_parameter_factory
 
-        model_args = set(arginfo(model_factory).args)
+        info = arginfo(model_factory)
+        assert info is not None
+        model_args = set(info.args)
         wants_request = "request" in model_args
         wants_app = "app" in model_args
 
-        def create(path_variables, request):
+        def create(path_variables: dict[str, Any], request: Request) -> Any:
             variables = parameter_factory(request)
             if wants_request:
                 variables["request"] = request
@@ -356,7 +378,7 @@ class TrajectRegistry:
         node.create = create
         node.absorb = absorb
 
-    def consume(self, request):
+    def consume(self, request: Request) -> Any:
         """Consume a stack given route, returning object.
 
         Removes the successfully consumed path segments from
@@ -411,15 +433,21 @@ class ParameterFactory:
     :param extra: should extra unknown parameters be included?
     """
 
-    def __init__(self, parameters, converters, required, extra=False):
+    def __init__(
+        self,
+        parameters: dict[str, Any] | None,
+        converters: dict[str, Any],
+        required: Collection[str],
+        extra: bool = False,
+    ) -> None:
         self.parameters = parameters
         self.converters = converters
         self.required = required
         self.extra = extra
 
-    def __call__(self, request):
+    def __call__(self, request: Request) -> dict[str, Any]:
         """Convert URL parameters to Python dictionary with values."""
-        result = {}
+        result: dict[str, Any] = {}
         # it's possible we are not actually interested in parameters
         # but this parameter factory is used as we defined converters
         if not self.parameters:
@@ -446,7 +474,7 @@ class ParameterFactory:
             return result
 
         remaining = set(url_parameters.keys()).difference(set(result.keys()))
-        extra = {}
+        extra: dict[str, str] = {}
         for name in remaining:
             value = url_parameters.getall(name)
             converter = self.converters.get(name, IDENTITY_CONVERTER)
@@ -460,11 +488,11 @@ class ParameterFactory:
         return result
 
 
-def _simple_parameter_factory(request):
+def _simple_parameter_factory(request: Request) -> dict[str, Any]:
     return {}
 
 
-def create_path(segments):
+def create_path(segments: list[str]) -> str:
     """Builds a path from a list of segments.
 
     :param stack: a list of segments
@@ -473,7 +501,7 @@ def create_path(segments):
     return "/" + "/".join(segments)
 
 
-def parse_path(path):
+def parse_path(path: str) -> list[str]:
     """Parses path, creates normalized segment list.
 
     Dots are collapsed:
@@ -485,7 +513,7 @@ def parse_path(path):
     :return: normalized list of path segments.
     """
     segments = path.split("/")
-    result = []
+    result: list[str] = []
     for segment in segments:
         if not segment or segment == ".":
             continue
@@ -499,7 +527,7 @@ def parse_path(path):
     return result
 
 
-def normalize_path(path):
+def normalize_path(path: str) -> str:
     """Converts path into normalized path.
 
     Rules:
@@ -530,7 +558,7 @@ def normalize_path(path):
     return create_path(parse_path(path))
 
 
-def is_identifier(s):
+def is_identifier(s: str) -> bool:
     """Check whether a variable name is a proper identifier.
 
     :param s: variable
@@ -539,7 +567,7 @@ def is_identifier(s):
     return IDENTIFIER.match(s) is not None
 
 
-def parse_variables(s):
+def parse_variables(s: str) -> list[str]:
     """Parse variables out of a segment.
 
     Raised a :class:`morepath.error.TrajectError` if a variable
@@ -555,20 +583,20 @@ def parse_variables(s):
     return result
 
 
-def create_variables_re(s):
+def create_variables_re(s: str) -> re.Pattern[str]:
     """Create regular expression that matches variables from route segment.
 
     :param s: a route segment with variables in it.
     :return: a regular expression that matches with variables for the route.
     """
 
-    def _repl(m):
+    def _repl(m: re.Match[str]) -> str:
         return "(?P<%s>.+)" % m.group(0)[1:-1]
 
     return re.compile("^" + PATH_VARIABLE.sub(_repl, s) + "$")
 
 
-def generalize_variables(s):
+def generalize_variables(s: str) -> str:
     """Generalize a route segment.
 
     :param s: a route segment.
@@ -577,7 +605,7 @@ def generalize_variables(s):
     return PATH_VARIABLE.sub("{}", s)
 
 
-def interpolation_str(s):
+def interpolation_str(s: str) -> str:
     """Create a Python string with interpolation variables for a route segment.
 
     Given ``a{foo}b``, creates ``a%sb``.

--- a/morepath/tween.py
+++ b/morepath/tween.py
@@ -10,16 +10,29 @@ Used by :meth:`morepath.App.tween_factory`.
 See also :class:`morepath.directive.TweenRegistry`
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from .toposort import Info, toposorted
+
+if TYPE_CHECKING:
+    from .app import App
+    from .types import Tween, TweenFactory
 
 
 class TweenRegistry:
     """Registry for tweens."""
 
-    def __init__(self):
-        self._tween_infos = []
+    def __init__(self) -> None:
+        self._tween_infos: list[Info[TweenFactory]] = []
 
-    def register_tween_factory(self, tween_factory, over, under):
+    def register_tween_factory(
+        self,
+        tween_factory: TweenFactory,
+        over: TweenFactory | None,
+        under: TweenFactory | None,
+    ) -> None:
         """Register a tween factory.
 
         :param tween_factory: a function that constructs a tween given
@@ -33,14 +46,14 @@ class TweenRegistry:
         """
         self._tween_infos.append(Info(tween_factory, over, under))
 
-    def sorted_tween_factories(self):
+    def sorted_tween_factories(self) -> list[TweenFactory]:
         """Sort tween factories topologically by over and under.
 
         :return: a sorted list of tween infos.
         """
         return [info.key for info in toposorted(self._tween_infos)]
 
-    def wrap(self, app):
+    def wrap(self, app: App) -> Tween:
         """Wrap app with tweens.
 
         This wraps :func:`morepath.publish.publish` with tweens.
@@ -50,7 +63,9 @@ class TweenRegistry:
           that takes request and returns a a response.
         """
         # to avoid circular import import publish here
-        from .publish import publish as result
+        from .publish import publish
+
+        result: Tween = publish
 
         for tween_factory in reversed(self.sorted_tween_factories()):
             result = tween_factory(app, result)

--- a/morepath/types.py
+++ b/morepath/types.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from os import PathLike
+from types import TracebackType
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Concatenate,
+    ParamSpec,
+    Protocol,
+    TypeAlias,
+)
+
+from webob import Response as BaseResponse
+
+from .app import App
+from .converter import Converter, ListConverter
+from .request import Request
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeVar
+
+    AppT = TypeVar("AppT", bound=App, default=Any)
+    RequestT = TypeVar("RequestT", bound=Request[Any], default=Any)
+    TweenT = TypeVar("TweenT", bound="Tween", default=Any)
+else:
+    from typing import TypeVar
+
+    AppT = TypeVar("AppT", bound=App)
+    RequestT = TypeVar("RequestT", bound=Request[Any])
+    TweenT = TypeVar("TweenT", bound="Tween")
+
+
+_T = TypeVar("_T")
+_KT_co = TypeVar("_KT_co", covariant=True)
+_VT_co = TypeVar("_VT_co", covariant=True)
+_P = ParamSpec("_P")
+
+
+class SupportsItems(Protocol[_KT_co, _VT_co]):
+    def items(self) -> Iterable[tuple[_KT_co, _VT_co]]: ...
+
+
+class StartResponse(Protocol):
+    def __call__(
+        self,
+        status: str,
+        headers: list[tuple[str, str]],
+        exc_info: OptExcInfo | None = ...,
+        /,
+    ) -> Callable[[bytes], object]: ...
+
+
+# NOTE: We would like these to have an upper bound of App/Request
+#       but that's not currently possible to express
+AnyApp: TypeAlias = Any
+AnyRequest: TypeAlias = Any
+AnyConverter: TypeAlias = Converter[Any] | ListConverter[Any]
+Tween: TypeAlias = Callable[[RequestT], BaseResponse]
+TweenFactory: TypeAlias = Callable[[AppT, TweenT], Tween]
+WSGIEnvironment: TypeAlias = dict[str, Any]
+WSGIApplication: TypeAlias = Callable[
+    [WSGIEnvironment, StartResponse], Iterable[bytes]
+]
+ExcInfo: TypeAlias = tuple[type[BaseException], BaseException, TracebackType]
+OptExcInfo: TypeAlias = ExcInfo | tuple[None, None, None]
+StrPath: TypeAlias = PathLike[str] | str
+GetStrPath: TypeAlias = Callable[[], StrPath]
+MaybeTakesApp: TypeAlias = (
+    Callable[Concatenate[AnyApp, _P], _T] | Callable[_P, _T]
+)
+Render: TypeAlias = Callable[[Any, AnyRequest], BaseResponse]
+GetRender: TypeAlias = Callable[[Any, str, Render], Render]

--- a/morepath/view.py
+++ b/morepath/view.py
@@ -11,10 +11,26 @@ this structure can be converted to HTML using a template.
 
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, TypeVar, overload
+
 from webob import Response as BaseResponse
 from webob.exc import HTTPForbidden, HTTPFound, HTTPNotFound
 
 from .request import Response
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from dectate.config import CodeInfo
+
+    from .app import App
+    from .request import Request
+
+_T = TypeVar("_T")
+_LoadedT = TypeVar("_LoadedT")
+_RequestT = TypeVar("_RequestT", bound="Request", contravariant=True)
 
 
 class View:
@@ -36,15 +52,72 @@ class View:
       and will be 404 Not Found.
     """
 
+    @overload
     def __init__(
         self,
-        func,
-        render=None,
-        load=None,
-        permission=None,
-        internal=False,
-        code_info=None,
-    ):
+        # we are lax and allow views that depend on subclasses of Request
+        func: Callable[[Any, _RequestT], BaseResponse | bytes | str | None],
+        render: None = None,
+        load: None = None,
+        permission: object | None = None,
+        internal: bool = False,
+        code_info: CodeInfo | None = None,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        func: Callable[[Any, _RequestT], BaseResponse | _T],
+        render: Callable[[_T, _RequestT], BaseResponse],
+        load: None = None,
+        permission: object | None = None,
+        internal: bool = False,
+        code_info: CodeInfo | None = None,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        func: Callable[[Any, _RequestT, _LoadedT], BaseResponse | _T],
+        render: Callable[[_T, _RequestT], BaseResponse],
+        load: Callable[[_RequestT], _LoadedT],
+        permission: object | None = None,
+        internal: bool = False,
+        code_info: CodeInfo | None = None,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        func: Callable[
+            [Any, _RequestT, _LoadedT], BaseResponse | bytes | str | None
+        ],
+        render: None,
+        load: Callable[[_RequestT], _LoadedT],
+        permission: object | None = None,
+        internal: bool = False,
+        code_info: CodeInfo | None = None,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        func: Callable[
+            [Any, _RequestT, _LoadedT], BaseResponse | bytes | str | None
+        ],
+        render: None = None,
+        *,
+        load: Callable[[_RequestT], _LoadedT],
+        permission: object | None = None,
+        internal: bool = False,
+        code_info: CodeInfo | None = None,
+    ) -> None: ...
+
+    def __init__(
+        self,
+        func: Callable[..., BaseResponse | Any],
+        render: Callable[[_T, Any], BaseResponse] | None = None,
+        load: Callable[[Any], _LoadedT] | None = None,
+        permission: object | None = None,
+        internal: bool = False,
+        code_info: CodeInfo | None = None,
+    ) -> None:
         self.func = func
         self.render = render or render_view
         self.load = load
@@ -52,7 +125,7 @@ class View:
         self.internal = internal
         self.code_info = code_info
 
-    def __call__(self, app, obj, request):
+    def __call__(self, app: App, obj: object, request: Request) -> BaseResponse:
         """Render a model instance.
 
         If view is internal it cannot be rendered.
@@ -91,7 +164,7 @@ class View:
         return response
 
 
-def render_view(content, request):
+def render_view(content: str, request: Request) -> Response:
     """Default render function for view if none was supplied.
 
     This just assumes the content is a string and renders it into
@@ -104,7 +177,7 @@ def render_view(content, request):
     return Response(content, content_type="text/plain")
 
 
-def render_json(content, request):
+def render_json(content: Any, request: Request) -> Response:
     """Take dict/list/string/number content and return json response.
 
     This respects the :meth:`morepath.App.dump_json` directive that
@@ -122,7 +195,7 @@ def render_json(content, request):
     )
 
 
-def render_html(content, request):
+def render_html(content: str, request: Request) -> Response:
     """Take string and return text/html response.
 
     :param content: contnet as returned from view function.
@@ -133,7 +206,7 @@ def render_html(content, request):
     return Response(content, content_type="text/html")
 
 
-def redirect(location):
+def redirect(location: str) -> HTTPFound:
     """Return a response object that redirects to location.
 
     :param location: a URL to redirect to.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 requires-python = ">= 3.10"
 dependencies = [
-    "webob >= 1.7.0",
+    "WebOb >= 1.7.0",
     "reg >= 0.12",
     "dectate >= 0.14",
     "importscan >= 0.2"
@@ -41,13 +41,18 @@ Issues = "https://github.com/morepath/morepath/issues"
 Changelog = "https://github.com/morepath/morepath/blob/master/CHANGES.txt"
 
 [project.optional-dependencies]
-test = ["pytest >= 8", "WebTest >= 2.0.14", "pytest-env"]
+test = ["pytest >= 8", "pytest-env", "WebTest >= 2.0.14"]
 docs = ["sphinx", "pyyaml", "WebTest >= 2.0.14"]
 coverage = ["pytest-cov"]
-lint = ["black", "flake8", "isort"]
+lint = ["black", "flake8", "flake8-pyproject", "isort"]
+mypy = ["mypy", "pytest", "types-WebOb", "types-WebTest"]
+pyright = ["pyright", "pytest", "types-WebOb", "types-WebTest", "WebTest >= 2.0.14"]
 
 [tool.setuptools.packages]
 find = {}
+
+[tool.setuptools.package-data]
+morepath = ["py.typed"]
 
 [tool.setuptools.dynamic]
 readme = {file = ["README.rst", "CHANGES.txt"]}
@@ -62,11 +67,48 @@ filterwarnings = [
 ]
 
 [tool.coverage.run]
-omit = ["morepath/tests/*"]
+omit = ["morepath/tests/*", "morepath/types.py"]
 source = ["morepath"]
 
 [tool.coverage.report]
 show_missing = true
+
+[tool.flake8]
+ignore = ["E203", "E231", "E301", "E501", "E704", "W503"]
+show-source = true
+max-line-length = 90
+
+[tool.mypy]
+python_version = "3.10"
+strict = true
+warn_unreachable = true
+untyped_calls_exclude = "morepath.tests.fixtures"
+
+[[tool.mypy.overrides]]
+module = ["morepath.tests.fixtures.*"]
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = [
+    "base.*",
+    "entrypoint.*",
+    "no_mp.*",
+    "ns.*",
+    "no_mp_sub.*",
+    "sub.*",
+    "under_score.*",
+]
+ignore_missing_imports = true
+
+[tool.pyright]
+exclude = [
+    "**/pdbsupport.py",
+    "**/tests/fixtures/**",
+]
+
+[[tool.pyright.executionEnvironments]]
+root = "morepath/tests/test_autosetup.py"
+reportMissingImports = "none"
 
 [tool.tox]
 requires = ["tox>=4"]
@@ -124,6 +166,28 @@ commands = [
     ["sphinx-build", "-b", "doctest", "doc", "{env_tmp_dir}"],
 ]
 
+[tool.tox.env.mypy]
+base_python = ["python3"]
+extras = ["mypy"]
+commands = [
+    ["mypy", "-p", "morepath", "--python-version", "3.10"],
+    ["mypy", "-p", "morepath", "--python-version", "3.11"],
+    ["mypy", "-p", "morepath", "--python-version", "3.12"],
+    ["mypy", "-p", "morepath", "--python-version", "3.13"],
+    ["mypy", "-p", "morepath", "--python-version", "3.14"],
+]
+
+[tool.tox.env.pyright]
+base_python = ["python3"]
+extras = ["pyright"]
+commands = [
+    ["pyright", "morepath", "--pythonversion", "3.10"],
+    ["pyright", "morepath", "--pythonversion", "3.11"],
+    ["pyright", "morepath", "--pythonversion", "3.12"],
+    ["pyright", "morepath", "--pythonversion", "3.13"],
+    ["pyright", "morepath", "--pythonversion", "3.14"],
+]
+
 [tool.black]
 line-length = 80
 target-version = ['py310', 'py311', 'py312', 'py313', 'py314']
@@ -148,3 +212,5 @@ exclude = '''
 profile = 'black'
 py_version = 311
 skip_gitignore = true
+extra_standard_library = ["typing_extensions"]
+known_first_party = ["dectate", "importscan", "reg"]

--- a/requirements/corelibs.txt
+++ b/requirements/corelibs.txt
@@ -1,4 +1,4 @@
 # Points to the master branches of Reg and Dectate on Github
--e git+https://github.com/morepath/reg.git@master#egg=reg
--e git+https://github.com/morepath/dectate.git@master#egg=dectate
--e git+https://github.com/morepath/importscan.git@master#egg=importscan
+git+https://github.com/morepath/reg.git@master#egg=reg
+git+https://github.com/morepath/dectate.git@master#egg=dectate
+git+https://github.com/morepath/importscan.git@master#egg=importscan


### PR DESCRIPTION
I also a fixed a small bug I saw in `Request.view` and cleaned up a couple of old Python 2 compat things, that would've been annoying to keep with type checkers.

I changed the implementation of `morepath.path.get_arguments` slightly as well, since type checkers weren't happy with the old one. There is a slight difference in the output, in that the order of the elements in the dictionary will be reversed, but for our use-case that's fine, since we only use it as a lookup, we never iterate over it in a way where the order would matter.

I had to switch to a regular install from an editable install, since mypy would otherwise not be able to see the type hints, without manually modifying `MYPY_PATH`. But I think that's fine, since an editable install doesn't give us anything when the source is an external URL, rather than a local path. You can still manually perform an editable install of your local development versions of these dependencies.

I updated the isort configuration, so it detects `dectate`, `importscan` and `reg` as fist party, even if they are not installed in editable mode.

Other than that I tried to leave things as they were.

As for the type hints themselves. One minor pain point is that you do not get any validation for the things decorated by directives, i.e. if you decorate something with `@App.view()` that doesn't have the correct parameters, you will not get an error. While it would be possible to add this validation, we would then start erasing the exact type of the decorated callables, so until higher kinded type variables are a thing, I think it's better to just forego this validation layer.

~~The mypy checks will fail until https://github.com/morepath/importscan/pull/18 has been merged.~~

\cc @henri-hulski 